### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665098471,
-        "narHash": "sha256-sNy1nfNg/p/q7JqsJtEOWbV3m5i5M89FzAJwbIn6W2Y=",
+        "lastModified": 1665271265,
+        "narHash": "sha256-4Nn0T5YoR3bBLFnPy6Tkc8zzmzMTBjSGZq05c5hKhEI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "be2cade373d96b469e5f4bb22c40cac87cf5a6f0",
+        "rev": "e1f1160284198a68ea8c7fffbbb1436f99e46ef9",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664989420,
-        "narHash": "sha256-Q8IxomUjjmewsoJgO3htkXLfCckQ7HkDJ/ZhdYVf/fA=",
+        "lastModified": 1665081174,
+        "narHash": "sha256-6hsmzdhdy8Kbvl5e0xZNE83pW3fKQvNiobJkM6KQrgA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "37bd39839acf99c5b738319f42478296f827f274",
+        "rev": "598f83ebeb2235435189cf84d844b8b73e858e0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/be2cade373d96b469e5f4bb22c40cac87cf5a6f0` →
  `github:nix-community/home-manager/e1f1160284198a68ea8c7fffbbb1436f99e46ef9`
  __([view changes](https://github.com/nix-community/home-manager/compare/be2cade373d96b469e5f4bb22c40cac87cf5a6f0...e1f1160284198a68ea8c7fffbbb1436f99e46ef9))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/37bd39839acf99c5b738319f42478296f827f274` →
  `github:nixos/nixpkgs/598f83ebeb2235435189cf84d844b8b73e858e0f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/37bd39839acf99c5b738319f42478296f827f274...598f83ebeb2235435189cf84d844b8b73e858e0f))__