### PR TITLE
build(deps): bump flake input `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665081174,
-        "narHash": "sha256-6hsmzdhdy8Kbvl5e0xZNE83pW3fKQvNiobJkM6KQrgA=",
+        "lastModified": 1665259268,
+        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "598f83ebeb2235435189cf84d844b8b73e858e0f",
+        "rev": "c5924154f000e6306030300592f4282949b2db6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __nixpkgs:__ 
  `github:nixos/nixpkgs/598f83ebeb2235435189cf84d844b8b73e858e0f` →
  `github:nixos/nixpkgs/c5924154f000e6306030300592f4282949b2db6c`
  __([view changes](https://github.com/nixos/nixpkgs/compare/598f83ebeb2235435189cf84d844b8b73e858e0f...c5924154f000e6306030300592f4282949b2db6c))__