### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665271265,
-        "narHash": "sha256-4Nn0T5YoR3bBLFnPy6Tkc8zzmzMTBjSGZq05c5hKhEI=",
+        "lastModified": 1665863351,
+        "narHash": "sha256-u8YWmHBTXWvQPBfKOrPWFVjvqhJ+5hUk3/29eR7APko=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1f1160284198a68ea8c7fffbbb1436f99e46ef9",
+        "rev": "2ecb3ea990cf737cfb42d8cd805fa86347c1afaf",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665259268,
-        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
+        "lastModified": 1665732960,
+        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5924154f000e6306030300592f4282949b2db6c",
+        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/e1f1160284198a68ea8c7fffbbb1436f99e46ef9` →
  `github:nix-community/home-manager/2ecb3ea990cf737cfb42d8cd805fa86347c1afaf`
  __([view changes](https://github.com/nix-community/home-manager/compare/e1f1160284198a68ea8c7fffbbb1436f99e46ef9...2ecb3ea990cf737cfb42d8cd805fa86347c1afaf))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/c5924154f000e6306030300592f4282949b2db6c` →
  `github:nixos/nixpkgs/4428e23312933a196724da2df7ab78eb5e67a88e`
  __([view changes](https://github.com/nixos/nixpkgs/compare/c5924154f000e6306030300592f4282949b2db6c...4428e23312933a196724da2df7ab78eb5e67a88e))__