### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665863351,
-        "narHash": "sha256-u8YWmHBTXWvQPBfKOrPWFVjvqhJ+5hUk3/29eR7APko=",
+        "lastModified": 1666463764,
+        "narHash": "sha256-NmayV9S0s7CgNEA2QbIxDU0VCIiX6bIHu8PCQPnYHDM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2ecb3ea990cf737cfb42d8cd805fa86347c1afaf",
+        "rev": "69d19b9839638fc487b370e0600a03577a559081",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661772734,
-        "narHash": "sha256-DkvAaLDg9D6O0i2MzUknaf/U078K4KWAZaJQmNC/tL8=",
+        "lastModified": 1665989030,
+        "narHash": "sha256-MZ0jKF3D0n0duUCgoF9VTurf0rjXQL4BO86hxYzTzuY=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "c1b0259313f661cf74051c916cf3bb4f061ce11f",
+        "rev": "d546cd7fd534d5208f43e7918d6ab68294f9d4dc",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665732960,
-        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
+        "lastModified": 1666377499,
+        "narHash": "sha256-dZZCGvWcxc7oGnUgFVf0UeNHsJ4VhkTM0v5JRe8EwR8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
+        "rev": "301aada7a64812853f2e2634a530ef5d34505048",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/2ecb3ea990cf737cfb42d8cd805fa86347c1afaf` →
  `github:nix-community/home-manager/69d19b9839638fc487b370e0600a03577a559081`
  __([view changes](https://github.com/nix-community/home-manager/compare/2ecb3ea990cf737cfb42d8cd805fa86347c1afaf...69d19b9839638fc487b370e0600a03577a559081))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/c1b0259313f661cf74051c916cf3bb4f061ce11f` →
  `github:nix-community/NixOS-WSL/d546cd7fd534d5208f43e7918d6ab68294f9d4dc`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/c1b0259313f661cf74051c916cf3bb4f061ce11f...d546cd7fd534d5208f43e7918d6ab68294f9d4dc))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/4428e23312933a196724da2df7ab78eb5e67a88e` →
  `github:nixos/nixpkgs/301aada7a64812853f2e2634a530ef5d34505048`
  __([view changes](https://github.com/nixos/nixpkgs/compare/4428e23312933a196724da2df7ab78eb5e67a88e...301aada7a64812853f2e2634a530ef5d34505048))__