### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666463764,
-        "narHash": "sha256-NmayV9S0s7CgNEA2QbIxDU0VCIiX6bIHu8PCQPnYHDM=",
+        "lastModified": 1666990295,
+        "narHash": "sha256-JPMTX8W36IPV1jmKV1qEhNBI4MbIPYsnccWyTUlSiG0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "69d19b9839638fc487b370e0600a03577a559081",
+        "rev": "423211401c245934db5052e3867cac704f658544",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665989030,
-        "narHash": "sha256-MZ0jKF3D0n0duUCgoF9VTurf0rjXQL4BO86hxYzTzuY=",
+        "lastModified": 1666720338,
+        "narHash": "sha256-7V91ZtTz7zDXb6hivktQ9RlBglP+WEkYFSciPJHwMJw=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "d546cd7fd534d5208f43e7918d6ab68294f9d4dc",
+        "rev": "7bfb8f5aa91fee30a189eae32cda8ddc465076df",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666377499,
-        "narHash": "sha256-dZZCGvWcxc7oGnUgFVf0UeNHsJ4VhkTM0v5JRe8EwR8=",
+        "lastModified": 1667050928,
+        "narHash": "sha256-xOn0ZgjImIyeecEsrjxuvlW7IW5genTwvvnDQRFncB8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "301aada7a64812853f2e2634a530ef5d34505048",
+        "rev": "fdebb81f45a1ba2c4afca5fd9f526e1653ad0949",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0` →
  `github:numtide/flake-utils/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817`
  __([view changes](https://github.com/numtide/flake-utils/compare/c0e246b9b83f637f4681389ecabcb2681b4f3af0...6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817))__
* __home-manager:__ 
  `github:nix-community/home-manager/69d19b9839638fc487b370e0600a03577a559081` →
  `github:nix-community/home-manager/423211401c245934db5052e3867cac704f658544`
  __([view changes](https://github.com/nix-community/home-manager/compare/69d19b9839638fc487b370e0600a03577a559081...423211401c245934db5052e3867cac704f658544))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/d546cd7fd534d5208f43e7918d6ab68294f9d4dc` →
  `github:nix-community/NixOS-WSL/7bfb8f5aa91fee30a189eae32cda8ddc465076df`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/d546cd7fd534d5208f43e7918d6ab68294f9d4dc...7bfb8f5aa91fee30a189eae32cda8ddc465076df))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/301aada7a64812853f2e2634a530ef5d34505048` →
  `github:nixos/nixpkgs/fdebb81f45a1ba2c4afca5fd9f526e1653ad0949`
  __([view changes](https://github.com/nixos/nixpkgs/compare/301aada7a64812853f2e2634a530ef5d34505048...fdebb81f45a1ba2c4afca5fd9f526e1653ad0949))__