### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667077288,
-        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666990295,
-        "narHash": "sha256-JPMTX8W36IPV1jmKV1qEhNBI4MbIPYsnccWyTUlSiG0=",
+        "lastModified": 1667691670,
+        "narHash": "sha256-9MgKg5LbTRuZ6oonP49go4jcUzkTOhVD3ZnQsi9aWM0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "423211401c245934db5052e3867cac704f658544",
+        "rev": "c5adf29545b553089ccf9c28b68973ce6f812c1c",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666720338,
-        "narHash": "sha256-7V91ZtTz7zDXb6hivktQ9RlBglP+WEkYFSciPJHwMJw=",
+        "lastModified": 1667710585,
+        "narHash": "sha256-+1Oejk8uk5i64FONNKY1+gcnLmDSBuk7MiYY2lP1GWI=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "7bfb8f5aa91fee30a189eae32cda8ddc465076df",
+        "rev": "ee805f89105e838d5e33dfaeb23192620d028df0",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667050928,
-        "narHash": "sha256-xOn0ZgjImIyeecEsrjxuvlW7IW5genTwvvnDQRFncB8=",
+        "lastModified": 1667629849,
+        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fdebb81f45a1ba2c4afca5fd9f526e1653ad0949",
+        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817` →
  `github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f`
  __([view changes](https://github.com/numtide/flake-utils/compare/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817...5aed5285a952e0b949eb3ba02c12fa4fcfef535f))__
* __home-manager:__ 
  `github:nix-community/home-manager/423211401c245934db5052e3867cac704f658544` →
  `github:nix-community/home-manager/c5adf29545b553089ccf9c28b68973ce6f812c1c`
  __([view changes](https://github.com/nix-community/home-manager/compare/423211401c245934db5052e3867cac704f658544...c5adf29545b553089ccf9c28b68973ce6f812c1c))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/7bfb8f5aa91fee30a189eae32cda8ddc465076df` →
  `github:nix-community/NixOS-WSL/ee805f89105e838d5e33dfaeb23192620d028df0`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/7bfb8f5aa91fee30a189eae32cda8ddc465076df...ee805f89105e838d5e33dfaeb23192620d028df0))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/fdebb81f45a1ba2c4afca5fd9f526e1653ad0949` →
  `github:nixos/nixpkgs/3bacde6273b09a21a8ccfba15586fb165078fb62`
  __([view changes](https://github.com/nixos/nixpkgs/compare/fdebb81f45a1ba2c4afca5fd9f526e1653ad0949...3bacde6273b09a21a8ccfba15586fb165078fb62))__