### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667691670,
-        "narHash": "sha256-9MgKg5LbTRuZ6oonP49go4jcUzkTOhVD3ZnQsi9aWM0=",
+        "lastModified": 1667981810,
+        "narHash": "sha256-p27zd5M+OkfND46gzbGkaHlNBZsYe95M48OJuFeuuSY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5adf29545b553089ccf9c28b68973ce6f812c1c",
+        "rev": "6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667710585,
-        "narHash": "sha256-+1Oejk8uk5i64FONNKY1+gcnLmDSBuk7MiYY2lP1GWI=",
+        "lastModified": 1667989099,
+        "narHash": "sha256-mVvXK09YCTkl79J442/4GDeDACB3QiwBvooxOURh3/Y=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "ee805f89105e838d5e33dfaeb23192620d028df0",
+        "rev": "a4bbcf329a98a7faf79d10370278f87e836e1d7c",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667629849,
-        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "lastModified": 1668087632,
+        "narHash": "sha256-T/cUx44aYDuLMFfaiVpMdTjL4kpG7bh0VkN6JEM78/E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "rev": "5f588eb4a958f1a526ed8da02d6ea1bea0047b9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/c5adf29545b553089ccf9c28b68973ce6f812c1c` →
  `github:nix-community/home-manager/6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335`
  __([view changes](https://github.com/nix-community/home-manager/compare/c5adf29545b553089ccf9c28b68973ce6f812c1c...6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/ee805f89105e838d5e33dfaeb23192620d028df0` →
  `github:nix-community/NixOS-WSL/a4bbcf329a98a7faf79d10370278f87e836e1d7c`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/ee805f89105e838d5e33dfaeb23192620d028df0...a4bbcf329a98a7faf79d10370278f87e836e1d7c))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/3bacde6273b09a21a8ccfba15586fb165078fb62` →
  `github:nixos/nixpkgs/5f588eb4a958f1a526ed8da02d6ea1bea0047b9f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/3bacde6273b09a21a8ccfba15586fb165078fb62...5f588eb4a958f1a526ed8da02d6ea1bea0047b9f))__