### PR TITLE
build(deps): bump flake inputs `flake-compat`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667981810,
-        "narHash": "sha256-p27zd5M+OkfND46gzbGkaHlNBZsYe95M48OJuFeuuSY=",
+        "lastModified": 1668900402,
+        "narHash": "sha256-IhVlueHoQNoN0SOHZIceKU3LyEL00g2ei0aUlaNypbQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335",
+        "rev": "c0f9cbcf93ca22e4f0ca66843be61a4bdf6f0a44",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667989099,
-        "narHash": "sha256-mVvXK09YCTkl79J442/4GDeDACB3QiwBvooxOURh3/Y=",
+        "lastModified": 1668383269,
+        "narHash": "sha256-jMtQZDoprTZR0VWn4rP3z3FFc5n5AvVJxdzCnwxPyyw=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "a4bbcf329a98a7faf79d10370278f87e836e1d7c",
+        "rev": "e9e8d01c5a2f57d330d42c9a772cf67d89b43650",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668087632,
-        "narHash": "sha256-T/cUx44aYDuLMFfaiVpMdTjL4kpG7bh0VkN6JEM78/E=",
+        "lastModified": 1668765800,
+        "narHash": "sha256-rC40+/W6Hio7b/RsY8SvQPKNx4WqNcTgfYv8cUMAvJk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f588eb4a958f1a526ed8da02d6ea1bea0047b9f",
+        "rev": "52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-compat:__ 
  `github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8` →
  `github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1`
  __([view changes](https://github.com/edolstra/flake-compat/compare/b4a34015c698c7793d592d66adbab377907a2be8...009399224d5e398d03b22badca40a37ac85412a1))__
* __home-manager:__ 
  `github:nix-community/home-manager/6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335` →
  `github:nix-community/home-manager/c0f9cbcf93ca22e4f0ca66843be61a4bdf6f0a44`
  __([view changes](https://github.com/nix-community/home-manager/compare/6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335...c0f9cbcf93ca22e4f0ca66843be61a4bdf6f0a44))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/a4bbcf329a98a7faf79d10370278f87e836e1d7c` →
  `github:nix-community/NixOS-WSL/e9e8d01c5a2f57d330d42c9a772cf67d89b43650`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/a4bbcf329a98a7faf79d10370278f87e836e1d7c...e9e8d01c5a2f57d330d42c9a772cf67d89b43650))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5f588eb4a958f1a526ed8da02d6ea1bea0047b9f` →
  `github:nixos/nixpkgs/52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5f588eb4a958f1a526ed8da02d6ea1bea0047b9f...52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739))__