### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669510155,
-        "narHash": "sha256-PS2WdRXujfxH9PuH0w8aRmrEQ+Toz3RqGlp0mXQRGio=",
+        "lastModified": 1670058827,
+        "narHash": "sha256-T+yyncPpZWeIkFrG/Cgj21iopULY3BZGWIhcT5ZmCgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e999dfe7cba2e1fd59ab135e7496545bd4f82b76",
+        "rev": "eb3598cf44aa10f2a16fe38488a102c0f474d766",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669401906,
-        "narHash": "sha256-/JlxSyN8pX4jLxJeY3HNolAwA227nfSCb3yts1uVpgo=",
+        "lastModified": 1669863592,
+        "narHash": "sha256-g0YVtM5Hi8k27yIWvPR7ZRRE1JscL6XtC5dv9Li1tMM=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "de5dd8238b591f2d39198ad036b85642bf828a29",
+        "rev": "522219248de4b5876f18e47f34d979dd9f4fcbdc",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669411043,
-        "narHash": "sha256-LfPd3+EY+jaIHTRIEOUtHXuanxm59YKgUacmSzaqMLc=",
+        "lastModified": 1670064435,
+        "narHash": "sha256-+ELoY30UN+Pl3Yn7RWRPabykwebsVK/kYE9JsIsUMxQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5dc7114b7b256d217fe7752f1614be2514e61bb8",
+        "rev": "61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/e999dfe7cba2e1fd59ab135e7496545bd4f82b76` →
  `github:nix-community/home-manager/eb3598cf44aa10f2a16fe38488a102c0f474d766`
  __([view changes](https://github.com/nix-community/home-manager/compare/e999dfe7cba2e1fd59ab135e7496545bd4f82b76...eb3598cf44aa10f2a16fe38488a102c0f474d766))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/de5dd8238b591f2d39198ad036b85642bf828a29` →
  `github:nix-community/NixOS-WSL/522219248de4b5876f18e47f34d979dd9f4fcbdc`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/de5dd8238b591f2d39198ad036b85642bf828a29...522219248de4b5876f18e47f34d979dd9f4fcbdc))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5dc7114b7b256d217fe7752f1614be2514e61bb8` →
  `github:nixos/nixpkgs/61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5dc7114b7b256d217fe7752f1614be2514e61bb8...61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c))__