### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670058827,
-        "narHash": "sha256-T+yyncPpZWeIkFrG/Cgj21iopULY3BZGWIhcT5ZmCgM=",
+        "lastModified": 1670513770,
+        "narHash": "sha256-muL74fsbGA8K8WlZSPNWddOiuBnC54kAajncX6nXrh4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eb3598cf44aa10f2a16fe38488a102c0f474d766",
+        "rev": "054d9e3187ca00479e8036dc0e92900a384f30fd",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669863592,
-        "narHash": "sha256-g0YVtM5Hi8k27yIWvPR7ZRRE1JscL6XtC5dv9Li1tMM=",
+        "lastModified": 1670429900,
+        "narHash": "sha256-ubGSEL2tLkOj6+/u+vLl4F6Vz0QA+BIcVph5txWIc7w=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "522219248de4b5876f18e47f34d979dd9f4fcbdc",
+        "rev": "2e1cbbb565c6ad8ca7e5f17c743bb127b22d48f7",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670064435,
-        "narHash": "sha256-+ELoY30UN+Pl3Yn7RWRPabykwebsVK/kYE9JsIsUMxQ=",
+        "lastModified": 1670597555,
+        "narHash": "sha256-/k939P2S2246G6K5fyvC0U2IWvULhb4ZJg9K7ZxsX+k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c",
+        "rev": "2dea0f4c2d6e4603f54b2c56c22367e77869490c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/eb3598cf44aa10f2a16fe38488a102c0f474d766` →
  `github:nix-community/home-manager/054d9e3187ca00479e8036dc0e92900a384f30fd`
  __([view changes](https://github.com/nix-community/home-manager/compare/eb3598cf44aa10f2a16fe38488a102c0f474d766...054d9e3187ca00479e8036dc0e92900a384f30fd))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/522219248de4b5876f18e47f34d979dd9f4fcbdc` →
  `github:nix-community/NixOS-WSL/2e1cbbb565c6ad8ca7e5f17c743bb127b22d48f7`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/522219248de4b5876f18e47f34d979dd9f4fcbdc...2e1cbbb565c6ad8ca7e5f17c743bb127b22d48f7))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c` →
  `github:nixos/nixpkgs/2dea0f4c2d6e4603f54b2c56c22367e77869490c`
  __([view changes](https://github.com/nixos/nixpkgs/compare/61a8a98e6d557e6dd7ed0cdb54c3a3e3bbc5e25c...2dea0f4c2d6e4603f54b2c56c22367e77869490c))__