### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670513770,
-        "narHash": "sha256-muL74fsbGA8K8WlZSPNWddOiuBnC54kAajncX6nXrh4=",
+        "lastModified": 1673737886,
+        "narHash": "sha256-hNTqD0uIgpbtTI2Nuj/Q1lEFOOdZqqXpxoc8rMno2F0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "054d9e3187ca00479e8036dc0e92900a384f30fd",
+        "rev": "2827b5306462d91edec16a3d069b2d6e54c3079f",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670429900,
-        "narHash": "sha256-ubGSEL2tLkOj6+/u+vLl4F6Vz0QA+BIcVph5txWIc7w=",
+        "lastModified": 1673339198,
+        "narHash": "sha256-5EAIJq89sTFooJ5vhsnaw7mDtKVDICvCv2ul7+BXAgA=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "2e1cbbb565c6ad8ca7e5f17c743bb127b22d48f7",
+        "rev": "217178edb1127fb41ac4fd534d8a513c3dd3d81b",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670597555,
-        "narHash": "sha256-/k939P2S2246G6K5fyvC0U2IWvULhb4ZJg9K7ZxsX+k=",
+        "lastModified": 1673631141,
+        "narHash": "sha256-AprpYQ5JvLS4wQG/ghm2UriZ9QZXvAwh1HlgA/6ZEVQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2dea0f4c2d6e4603f54b2c56c22367e77869490c",
+        "rev": "befc83905c965adfd33e5cae49acb0351f6e0404",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/054d9e3187ca00479e8036dc0e92900a384f30fd` →
  `github:nix-community/home-manager/2827b5306462d91edec16a3d069b2d6e54c3079f`
  __([view changes](https://github.com/nix-community/home-manager/compare/054d9e3187ca00479e8036dc0e92900a384f30fd...2827b5306462d91edec16a3d069b2d6e54c3079f))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/2e1cbbb565c6ad8ca7e5f17c743bb127b22d48f7` →
  `github:nix-community/NixOS-WSL/217178edb1127fb41ac4fd534d8a513c3dd3d81b`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/2e1cbbb565c6ad8ca7e5f17c743bb127b22d48f7...217178edb1127fb41ac4fd534d8a513c3dd3d81b))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/2dea0f4c2d6e4603f54b2c56c22367e77869490c` →
  `github:nixos/nixpkgs/befc83905c965adfd33e5cae49acb0351f6e0404`
  __([view changes](https://github.com/nixos/nixpkgs/compare/2dea0f4c2d6e4603f54b2c56c22367e77869490c...befc83905c965adfd33e5cae49acb0351f6e0404))__