### PR TITLE
build(deps): bump flake inputs `flake-compat`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673737886,
-        "narHash": "sha256-hNTqD0uIgpbtTI2Nuj/Q1lEFOOdZqqXpxoc8rMno2F0=",
+        "lastModified": 1674250603,
+        "narHash": "sha256-SBolFspxBHpW3hCCDNAFXUiO2mucmkVmf17UmSIK3Cs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2827b5306462d91edec16a3d069b2d6e54c3079f",
+        "rev": "275ab728912006eecb549338a50f24f294a7cfb7",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673339198,
-        "narHash": "sha256-5EAIJq89sTFooJ5vhsnaw7mDtKVDICvCv2ul7+BXAgA=",
+        "lastModified": 1674151125,
+        "narHash": "sha256-7kkdtTKfvoAzGV8F7gCr1WX6FMadF6s8a1QUaMHOSzA=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "217178edb1127fb41ac4fd534d8a513c3dd3d81b",
+        "rev": "13f5b22fb03ed3c22522c9e7d5e3403fb318070e",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673631141,
-        "narHash": "sha256-AprpYQ5JvLS4wQG/ghm2UriZ9QZXvAwh1HlgA/6ZEVQ=",
+        "lastModified": 1674211260,
+        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "befc83905c965adfd33e5cae49acb0351f6e0404",
+        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-compat:__ 
  `github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1` →
  `github:edolstra/flake-compat/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9`
  __([view changes](https://github.com/edolstra/flake-compat/compare/009399224d5e398d03b22badca40a37ac85412a1...35bb57c0c8d8b62bbfd284272c928ceb64ddbde9))__
* __home-manager:__ 
  `github:nix-community/home-manager/2827b5306462d91edec16a3d069b2d6e54c3079f` →
  `github:nix-community/home-manager/275ab728912006eecb549338a50f24f294a7cfb7`
  __([view changes](https://github.com/nix-community/home-manager/compare/2827b5306462d91edec16a3d069b2d6e54c3079f...275ab728912006eecb549338a50f24f294a7cfb7))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/217178edb1127fb41ac4fd534d8a513c3dd3d81b` →
  `github:nix-community/NixOS-WSL/13f5b22fb03ed3c22522c9e7d5e3403fb318070e`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/217178edb1127fb41ac4fd534d8a513c3dd3d81b...13f5b22fb03ed3c22522c9e7d5e3403fb318070e))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/befc83905c965adfd33e5cae49acb0351f6e0404` →
  `github:nixos/nixpkgs/5ed481943351e9fd354aeb557679624224de38d5`
  __([view changes](https://github.com/nixos/nixpkgs/compare/befc83905c965adfd33e5cae49acb0351f6e0404...5ed481943351e9fd354aeb557679624224de38d5))__