### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674250603,
-        "narHash": "sha256-SBolFspxBHpW3hCCDNAFXUiO2mucmkVmf17UmSIK3Cs=",
+        "lastModified": 1674928308,
+        "narHash": "sha256-elVU4NUZEl11BdT4gC+lrpLYM8Ccxqxs19Ix84HTI9o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "275ab728912006eecb549338a50f24f294a7cfb7",
+        "rev": "08a778d80308353f4f65c9dcd3790b5da02d6306",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674151125,
-        "narHash": "sha256-7kkdtTKfvoAzGV8F7gCr1WX6FMadF6s8a1QUaMHOSzA=",
+        "lastModified": 1674887006,
+        "narHash": "sha256-dPHPxrZ6642Y46eqBMNGu61qQqGmwV7liZEyle6v0IU=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "13f5b22fb03ed3c22522c9e7d5e3403fb318070e",
+        "rev": "14273c185311868e8525a0af3b5c93503e0f53e8",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674211260,
-        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/275ab728912006eecb549338a50f24f294a7cfb7` →
  `github:nix-community/home-manager/08a778d80308353f4f65c9dcd3790b5da02d6306`
  __([view changes](https://github.com/nix-community/home-manager/compare/275ab728912006eecb549338a50f24f294a7cfb7...08a778d80308353f4f65c9dcd3790b5da02d6306))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/13f5b22fb03ed3c22522c9e7d5e3403fb318070e` →
  `github:nix-community/NixOS-WSL/14273c185311868e8525a0af3b5c93503e0f53e8`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/13f5b22fb03ed3c22522c9e7d5e3403fb318070e...14273c185311868e8525a0af3b5c93503e0f53e8))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5ed481943351e9fd354aeb557679624224de38d5` →
  `github:nixos/nixpkgs/9b97ad7b4330aacda9b2343396eb3df8a853b4fc`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5ed481943351e9fd354aeb557679624224de38d5...9b97ad7b4330aacda9b2343396eb3df8a853b4fc))__