### PR TITLE
build(deps): bump flake inputs `flake-utils`, `nixpkgs`, `vscode-server`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675942811,
-        "narHash": "sha256-/v4Z9mJmADTpXrdIlAjFa1e+gkpIIROR670UVDQFwIw=",
+        "lastModified": 1676202775,
+        "narHash": "sha256-gV/RnfVZkGLHn+5rmX2GSh5aquVHpWOJw1cnpEV03tQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724bfc0892363087709bd3a5a1666296759154b1",
+        "rev": "d917136f550a8c36efb1724390c7245105f79023",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676159144,
-        "narHash": "sha256-/TJD9hZ0+u7oSJkNxmAE/UlxndFkZCu1fC6re7I/DYY=",
+        "lastModified": 1676380200,
+        "narHash": "sha256-R4CofmqRwFY0DUJvmNAWro8vHXkKmzr75dPCKYWSjKU=",
         "owner": "msteen",
         "repo": "nixos-vscode-server",
-        "rev": "43ca5e6d4e45ae6933aaeb1850b4cdf62c25a11f",
+        "rev": "1321083c4ffabcd4b94e72a4d11632ba2e24cf86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f` →
  `github:numtide/flake-utils/3db36a8b464d0c4532ba1c7dda728f4576d6d073`
  __([view changes](https://github.com/numtide/flake-utils/compare/5aed5285a952e0b949eb3ba02c12fa4fcfef535f...3db36a8b464d0c4532ba1c7dda728f4576d6d073))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/724bfc0892363087709bd3a5a1666296759154b1` →
  `github:nixos/nixpkgs/d917136f550a8c36efb1724390c7245105f79023`
  __([view changes](https://github.com/nixos/nixpkgs/compare/724bfc0892363087709bd3a5a1666296759154b1...d917136f550a8c36efb1724390c7245105f79023))__
* __vscode-server:__ 
  `github:msteen/nixos-vscode-server/43ca5e6d4e45ae6933aaeb1850b4cdf62c25a11f` →
  `github:msteen/nixos-vscode-server/1321083c4ffabcd4b94e72a4d11632ba2e24cf86`
  __([view changes](https://github.com/msteen/nixos-vscode-server/compare/43ca5e6d4e45ae6933aaeb1850b4cdf62c25a11f...1321083c4ffabcd4b94e72a4d11632ba2e24cf86))__