### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676367705,
-        "narHash": "sha256-un5UbRat9TwruyImtwUGcKF823rCEp4fQxnsaLFL7CM=",
+        "lastModified": 1677276957,
+        "narHash": "sha256-/vhdNhQj2CWgqdfD2KLEZWDleOfen0t2EiaGiyivnJU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5",
+        "rev": "664945b3e09b4551c4e63e16efebd493cf5eac74",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676721149,
-        "narHash": "sha256-mN2EpTGxxVNnFZLoLWRwh6f7UWhXy4qE+wO2CZyrXps=",
+        "lastModified": 1677342105,
+        "narHash": "sha256-kv1fpkfCJGb0M+LZaCHFUuIS9kRIwyVgupHu86Y28nc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f4e07deb7c44f27d498f8df9c5f34750acf52d2",
+        "rev": "b1f87ca164a9684404c8829b851c3586c4d9f089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5` →
  `github:nix-community/home-manager/664945b3e09b4551c4e63e16efebd493cf5eac74`
  __([view changes](https://github.com/nix-community/home-manager/compare/da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5...664945b3e09b4551c4e63e16efebd493cf5eac74))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5f4e07deb7c44f27d498f8df9c5f34750acf52d2` →
  `github:nixos/nixpkgs/b1f87ca164a9684404c8829b851c3586c4d9f089`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5f4e07deb7c44f27d498f8df9c5f34750acf52d2...b1f87ca164a9684404c8829b851c3586c4d9f089))__