### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677276957,
-        "narHash": "sha256-/vhdNhQj2CWgqdfD2KLEZWDleOfen0t2EiaGiyivnJU=",
+        "lastModified": 1677783711,
+        "narHash": "sha256-eq5mOVk3gv5HITtLhPjKwi8bFnOaQplA3X0WFgHnmxE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "664945b3e09b4551c4e63e16efebd493cf5eac74",
+        "rev": "b9e3a29864798d55ec1d6579ab97876bb1ee9664",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677342105,
-        "narHash": "sha256-kv1fpkfCJGb0M+LZaCHFUuIS9kRIwyVgupHu86Y28nc=",
+        "lastModified": 1677932085,
+        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b1f87ca164a9684404c8829b851c3586c4d9f089",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/664945b3e09b4551c4e63e16efebd493cf5eac74` →
  `github:nix-community/home-manager/b9e3a29864798d55ec1d6579ab97876bb1ee9664`
  __([view changes](https://github.com/nix-community/home-manager/compare/664945b3e09b4551c4e63e16efebd493cf5eac74...b9e3a29864798d55ec1d6579ab97876bb1ee9664))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/b1f87ca164a9684404c8829b851c3586c4d9f089` →
  `github:nixos/nixpkgs/3c5319ad3aa51551182ac82ea17ab1c6b0f0df89`
  __([view changes](https://github.com/nixos/nixpkgs/compare/b1f87ca164a9684404c8829b851c3586c4d9f089...3c5319ad3aa51551182ac82ea17ab1c6b0f0df89))__