### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677783711,
-        "narHash": "sha256-eq5mOVk3gv5HITtLhPjKwi8bFnOaQplA3X0WFgHnmxE=",
+        "lastModified": 1678571066,
+        "narHash": "sha256-MrlMr2A3tK1MY/JUGWMVzMwois8+mHWXm/1yYdwQSIc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9e3a29864798d55ec1d6579ab97876bb1ee9664",
+        "rev": "bf5712c5865e543fb3f4796511d4cf51efd841b1",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676381420,
-        "narHash": "sha256-aDRnfGrk/xi7zkuterN78p8/wdM5Iy6vz74uqd/JFWw=",
+        "lastModified": 1678325558,
+        "narHash": "sha256-TYuMGs3SqDn7RDuPPa8t7nAE+Ml3GFoN5m96zkRwaS8=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "4640199aeafcbb63cfbe8318bdf06f4402134f66",
+        "rev": "15ddd83dc3c50484633944984848a30be1d2dbf6",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677932085,
-        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
+        "lastModified": 1678470307,
+        "narHash": "sha256-OEeMUr3ueLIXyW/OaFUX5jUdimyQwMg/7e+/Q0gC/QE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "rev": "0c4800d579af4ed98ecc47d464a5e7b0870c4b1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/b9e3a29864798d55ec1d6579ab97876bb1ee9664` →
  `github:nix-community/home-manager/bf5712c5865e543fb3f4796511d4cf51efd841b1`
  __([view changes](https://github.com/nix-community/home-manager/compare/b9e3a29864798d55ec1d6579ab97876bb1ee9664...bf5712c5865e543fb3f4796511d4cf51efd841b1))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/4640199aeafcbb63cfbe8318bdf06f4402134f66` →
  `github:nix-community/NixOS-WSL/15ddd83dc3c50484633944984848a30be1d2dbf6`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/4640199aeafcbb63cfbe8318bdf06f4402134f66...15ddd83dc3c50484633944984848a30be1d2dbf6))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/3c5319ad3aa51551182ac82ea17ab1c6b0f0df89` →
  `github:nixos/nixpkgs/0c4800d579af4ed98ecc47d464a5e7b0870c4b1f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/3c5319ad3aa51551182ac82ea17ab1c6b0f0df89...0c4800d579af4ed98ecc47d464a5e7b0870c4b1f))__