### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679067095,
-        "narHash": "sha256-G2dJQURL/CCi+8RP6jNJG8VqgtzEMCA+6mNodd3VR6E=",
+        "lastModified": 1679786039,
+        "narHash": "sha256-VNjswu0Q4bZOkWNuc0+dHvRdjUCj+MnDlRfw/Q0R3vI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3239e0b40f242f47bf6c0c37b2fd35ab3e76e370",
+        "rev": "cf662b6c98a0da81e06066fff0ecf9cbd4627727",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679081381,
-        "narHash": "sha256-n4+SbrVohxbgbmOTkodfxc3d8W38OfKowD6YNA8j27o=",
+        "lastModified": 1679705136,
+        "narHash": "sha256-MDlZUR7wJ3PlPtqwwoGQr3euNOe0vdSSteVVOef7tBY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b573a7f69484a7d213680abb70b4f95bdc28eee5",
+        "rev": "8f40f2f90b9c9032d1b824442cfbbe0dbabd0dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/3239e0b40f242f47bf6c0c37b2fd35ab3e76e370` →
  `github:nix-community/home-manager/cf662b6c98a0da81e06066fff0ecf9cbd4627727`
  __([view changes](https://github.com/nix-community/home-manager/compare/3239e0b40f242f47bf6c0c37b2fd35ab3e76e370...cf662b6c98a0da81e06066fff0ecf9cbd4627727))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/b573a7f69484a7d213680abb70b4f95bdc28eee5` →
  `github:nixos/nixpkgs/8f40f2f90b9c9032d1b824442cfbbe0dbabd0dbd`
  __([view changes](https://github.com/nixos/nixpkgs/compare/b573a7f69484a7d213680abb70b4f95bdc28eee5...8f40f2f90b9c9032d1b824442cfbbe0dbabd0dbd))__