### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681586243,
-        "narHash": "sha256-vdP79IZuDZVNSl4RN1LgEuab1Tkbv4gCxiE8VLdRf7U=",
+        "lastModified": 1682203081,
+        "narHash": "sha256-kRL4ejWDhi0zph/FpebFYhzqlOBrk0Pl3dzGEKSAlEw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad",
+        "rev": "32d3e39c491e2f91152c84f8ad8b003420eab0a1",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681465517,
-        "narHash": "sha256-EasJh15/jcJNAHtq2SGbiADRXteURAnQbj1NqBoKkzU=",
+        "lastModified": 1681920287,
+        "narHash": "sha256-+/d6XQQfhhXVfqfLROJoqj3TuG38CAeoT6jO1g9r1k0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "abe7316dd51a313ce528972b104f4f04f56eefc4",
+        "rev": "645bc49f34fa8eff95479f0345ff57e55b53437e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad` →
  `github:nix-community/home-manager/32d3e39c491e2f91152c84f8ad8b003420eab0a1`
  __([view changes](https://github.com/nix-community/home-manager/compare/40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad...32d3e39c491e2f91152c84f8ad8b003420eab0a1))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/abe7316dd51a313ce528972b104f4f04f56eefc4` →
  `github:nixos/nixpkgs/645bc49f34fa8eff95479f0345ff57e55b53437e`
  __([view changes](https://github.com/nixos/nixpkgs/compare/abe7316dd51a313ce528972b104f4f04f56eefc4...645bc49f34fa8eff95479f0345ff57e55b53437e))__