### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`, `vscode-server`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683989410,
-        "narHash": "sha256-puF/QsIkp4ch0sf6M5mNzbdZtYcq2MJHcKre9wJ3ZYo=",
+        "lastModified": 1684596126,
+        "narHash": "sha256-4RZZmygeEXpuBqEXGs38ZAcWjWKGwu13Iqbxub6wuJk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6702b22b9805bc1879715d4111e3764cd4237aed",
+        "rev": "27ef11f0218d9018ebb2948d40133df2b1de622d",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683408522,
-        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "lastModified": 1684570954,
+        "narHash": "sha256-FX5y4Sm87RWwfu9PI71XFvuRpZLowh00FQpIJ1WfXqE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "rev": "3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683057558,
-        "narHash": "sha256-/kGv1CRaB1g+P1szq8acL0AwtyZMNHixdNFY2PvXViM=",
+        "lastModified": 1684517665,
+        "narHash": "sha256-SaAr66uCQ8CF75jIr23FZjk1+9Kfwm5sQnwV25206Gs=",
         "owner": "msteen",
         "repo": "nixos-vscode-server",
-        "rev": "e26b40ef083a9e9d48b5713b0d810fe5f4d0d555",
+        "rev": "1e1358493df6529d4c7bc4cc3066f76fd16d4ae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/6702b22b9805bc1879715d4111e3764cd4237aed` →
  `github:nix-community/home-manager/27ef11f0218d9018ebb2948d40133df2b1de622d`
  __([view changes](https://github.com/nix-community/home-manager/compare/6702b22b9805bc1879715d4111e3764cd4237aed...27ef11f0218d9018ebb2948d40133df2b1de622d))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/897876e4c484f1e8f92009fd11b7d988a121a4e7` →
  `github:nixos/nixpkgs/3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3`
  __([view changes](https://github.com/nixos/nixpkgs/compare/897876e4c484f1e8f92009fd11b7d988a121a4e7...3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3))__
* __vscode-server:__ 
  `github:msteen/nixos-vscode-server/e26b40ef083a9e9d48b5713b0d810fe5f4d0d555` →
  `github:msteen/nixos-vscode-server/1e1358493df6529d4c7bc4cc3066f76fd16d4ae6`
  __([view changes](https://github.com/msteen/nixos-vscode-server/compare/e26b40ef083a9e9d48b5713b0d810fe5f4d0d555...1e1358493df6529d4c7bc4cc3066f76fd16d4ae6))__