### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684596126,
-        "narHash": "sha256-4RZZmygeEXpuBqEXGs38ZAcWjWKGwu13Iqbxub6wuJk=",
+        "lastModified": 1685189510,
+        "narHash": "sha256-Hq5WF7zIixojPgvhgcd6MBvywwycVZ9wpK/8ogOyoaA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "27ef11f0218d9018ebb2948d40133df2b1de622d",
+        "rev": "2d963854ae2499193c0c72fd67435fee34d3e4fd",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684570954,
-        "narHash": "sha256-FX5y4Sm87RWwfu9PI71XFvuRpZLowh00FQpIJ1WfXqE=",
+        "lastModified": 1685168767,
+        "narHash": "sha256-wQgnxz0PdqbyKKpsWl/RU8T8QhJQcHfeC6lh1xRUTfk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3",
+        "rev": "e10802309bf9ae351eb27002c85cfdeb1be3b262",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/27ef11f0218d9018ebb2948d40133df2b1de622d` →
  `github:nix-community/home-manager/2d963854ae2499193c0c72fd67435fee34d3e4fd`
  __([view changes](https://github.com/nix-community/home-manager/compare/27ef11f0218d9018ebb2948d40133df2b1de622d...2d963854ae2499193c0c72fd67435fee34d3e4fd))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3` →
  `github:nixos/nixpkgs/e10802309bf9ae351eb27002c85cfdeb1be3b262`
  __([view changes](https://github.com/nixos/nixpkgs/compare/3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3...e10802309bf9ae351eb27002c85cfdeb1be3b262))__