### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685189510,
-        "narHash": "sha256-Hq5WF7zIixojPgvhgcd6MBvywwycVZ9wpK/8ogOyoaA=",
+        "lastModified": 1685833925,
+        "narHash": "sha256-KCo8QT/DtM4pSTQDWFOhVP7MDzwi0wb2ZlxhgjEwXtM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d963854ae2499193c0c72fd67435fee34d3e4fd",
+        "rev": "bffc49ffb255f213d2f902043da37b3016450f4a",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685168767,
-        "narHash": "sha256-wQgnxz0PdqbyKKpsWl/RU8T8QhJQcHfeC6lh1xRUTfk=",
+        "lastModified": 1685655444,
+        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e10802309bf9ae351eb27002c85cfdeb1be3b262",
+        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/cfacdce06f30d2b68473a46042957675eebb3401` →
  `github:numtide/flake-utils/a1720a10a6cfe8234c0e93907ffe81be440f4cef`
  __([view changes](https://github.com/numtide/flake-utils/compare/cfacdce06f30d2b68473a46042957675eebb3401...a1720a10a6cfe8234c0e93907ffe81be440f4cef))__
* __home-manager:__ 
  `github:nix-community/home-manager/2d963854ae2499193c0c72fd67435fee34d3e4fd` →
  `github:nix-community/home-manager/bffc49ffb255f213d2f902043da37b3016450f4a`
  __([view changes](https://github.com/nix-community/home-manager/compare/2d963854ae2499193c0c72fd67435fee34d3e4fd...bffc49ffb255f213d2f902043da37b3016450f4a))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/e10802309bf9ae351eb27002c85cfdeb1be3b262` →
  `github:nixos/nixpkgs/e635192892f5abbc2289eaac3a73cdb249abaefd`
  __([view changes](https://github.com/nixos/nixpkgs/compare/e10802309bf9ae351eb27002c85cfdeb1be3b262...e635192892f5abbc2289eaac3a73cdb249abaefd))__