### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685833925,
-        "narHash": "sha256-KCo8QT/DtM4pSTQDWFOhVP7MDzwi0wb2ZlxhgjEwXtM=",
+        "lastModified": 1686391840,
+        "narHash": "sha256-5S0APl6Mfm6a37taHwvuf11UHnAX0+PnoWQbsYbMUnc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bffc49ffb255f213d2f902043da37b3016450f4a",
+        "rev": "0144ac418ef633bfc9dbd89b8c199ad3a617c59f",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682982995,
-        "narHash": "sha256-PK0pSY48JkcLDFphafjpLqeTDs0XUqGMHjsiNuEq5s0=",
+        "lastModified": 1686130269,
+        "narHash": "sha256-3CVQARW+cANIPO9qGDlJ351lOY5qo+FVW2cI/sURvmw=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "c5d7db84c422be515dac8fc26420900c349374e8",
+        "rev": "d3b2fdbd9a0096764ebfd80c2f4bb8bcfbe920ce",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1686412476,
+        "narHash": "sha256-inl9SVk6o5h75XKC79qrDCAobTD1Jxh6kVYTZKHzewA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "21951114383770f96ae528d0ae68824557768e81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/bffc49ffb255f213d2f902043da37b3016450f4a` →
  `github:nix-community/home-manager/0144ac418ef633bfc9dbd89b8c199ad3a617c59f`
  __([view changes](https://github.com/nix-community/home-manager/compare/bffc49ffb255f213d2f902043da37b3016450f4a...0144ac418ef633bfc9dbd89b8c199ad3a617c59f))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/c5d7db84c422be515dac8fc26420900c349374e8` →
  `github:nix-community/NixOS-WSL/d3b2fdbd9a0096764ebfd80c2f4bb8bcfbe920ce`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/c5d7db84c422be515dac8fc26420900c349374e8...d3b2fdbd9a0096764ebfd80c2f4bb8bcfbe920ce))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/e635192892f5abbc2289eaac3a73cdb249abaefd` →
  `github:nixos/nixpkgs/21951114383770f96ae528d0ae68824557768e81`
  __([view changes](https://github.com/nixos/nixpkgs/compare/e635192892f5abbc2289eaac3a73cdb249abaefd...21951114383770f96ae528d0ae68824557768e81))__