### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686391840,
-        "narHash": "sha256-5S0APl6Mfm6a37taHwvuf11UHnAX0+PnoWQbsYbMUnc=",
+        "lastModified": 1687041769,
+        "narHash": "sha256-lPDVNMrDF/hOVy+P8pEtKzvSN/Akk9RbDcyNuvW1T+M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0144ac418ef633bfc9dbd89b8c199ad3a617c59f",
+        "rev": "edf9cf65238609db16680be74fe28d4d4858476e",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686130269,
-        "narHash": "sha256-3CVQARW+cANIPO9qGDlJ351lOY5qo+FVW2cI/sURvmw=",
+        "lastModified": 1686935553,
+        "narHash": "sha256-1m6X7WlJ7iV3F7c7C83mN/FGSksxyJkhvl8/fbOBNyU=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "d3b2fdbd9a0096764ebfd80c2f4bb8bcfbe920ce",
+        "rev": "701e37f027cda2e84868c38b5f010e3d35f023a4",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686412476,
-        "narHash": "sha256-inl9SVk6o5h75XKC79qrDCAobTD1Jxh6kVYTZKHzewA=",
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "21951114383770f96ae528d0ae68824557768e81",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/0144ac418ef633bfc9dbd89b8c199ad3a617c59f` →
  `github:nix-community/home-manager/edf9cf65238609db16680be74fe28d4d4858476e`
  __([view changes](https://github.com/nix-community/home-manager/compare/0144ac418ef633bfc9dbd89b8c199ad3a617c59f...edf9cf65238609db16680be74fe28d4d4858476e))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/d3b2fdbd9a0096764ebfd80c2f4bb8bcfbe920ce` →
  `github:nix-community/NixOS-WSL/701e37f027cda2e84868c38b5f010e3d35f023a4`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/d3b2fdbd9a0096764ebfd80c2f4bb8bcfbe920ce...701e37f027cda2e84868c38b5f010e3d35f023a4))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/21951114383770f96ae528d0ae68824557768e81` →
  `github:nixos/nixpkgs/04af42f3b31dba0ef742d254456dc4c14eedac86`
  __([view changes](https://github.com/nixos/nixpkgs/compare/21951114383770f96ae528d0ae68824557768e81...04af42f3b31dba0ef742d254456dc4c14eedac86))__