### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687171271,
+        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687041769,
-        "narHash": "sha256-lPDVNMrDF/hOVy+P8pEtKzvSN/Akk9RbDcyNuvW1T+M=",
+        "lastModified": 1687647343,
+        "narHash": "sha256-1/o/i9KEFOBdlF9Cs04kBcqDFbYMt6W4SMqGa+QnnaI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edf9cf65238609db16680be74fe28d4d4858476e",
+        "rev": "0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686935553,
-        "narHash": "sha256-1m6X7WlJ7iV3F7c7C83mN/FGSksxyJkhvl8/fbOBNyU=",
+        "lastModified": 1687279045,
+        "narHash": "sha256-LR0dsXd/A07M61jclyBUW0wRojEQteWReKM35zoJXp0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "701e37f027cda2e84868c38b5f010e3d35f023a4",
+        "rev": "a8486b5d191f11d571f15d80b6e265d1712d01cf",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686960236,
-        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
+        "lastModified": 1687502512,
+        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
+        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/a1720a10a6cfe8234c0e93907ffe81be440f4cef` →
  `github:numtide/flake-utils/abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c`
  __([view changes](https://github.com/numtide/flake-utils/compare/a1720a10a6cfe8234c0e93907ffe81be440f4cef...abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c))__
* __home-manager:__ 
  `github:nix-community/home-manager/edf9cf65238609db16680be74fe28d4d4858476e` →
  `github:nix-community/home-manager/0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179`
  __([view changes](https://github.com/nix-community/home-manager/compare/edf9cf65238609db16680be74fe28d4d4858476e...0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/701e37f027cda2e84868c38b5f010e3d35f023a4` →
  `github:nix-community/NixOS-WSL/a8486b5d191f11d571f15d80b6e265d1712d01cf`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/701e37f027cda2e84868c38b5f010e3d35f023a4...a8486b5d191f11d571f15d80b6e265d1712d01cf))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/04af42f3b31dba0ef742d254456dc4c14eedac86` →
  `github:nixos/nixpkgs/3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/04af42f3b31dba0ef742d254456dc4c14eedac86...3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f))__