### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687171271,
-        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687647343,
-        "narHash": "sha256-1/o/i9KEFOBdlF9Cs04kBcqDFbYMt6W4SMqGa+QnnaI=",
+        "lastModified": 1688220547,
+        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179",
+        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687502512,
-        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
+        "lastModified": 1688049487,
+        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
+        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c` →
  `github:numtide/flake-utils/dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7`
  __([view changes](https://github.com/numtide/flake-utils/compare/abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c...dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7))__
* __home-manager:__ 
  `github:nix-community/home-manager/0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179` →
  `github:nix-community/home-manager/89d10f8adce369a80e046c2fd56d1e7b7507bb5b`
  __([view changes](https://github.com/nix-community/home-manager/compare/0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179...89d10f8adce369a80e046c2fd56d1e7b7507bb5b))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f` →
  `github:nixos/nixpkgs/4bc72cae107788bf3f24f30db2e2f685c9298dc9`
  __([view changes](https://github.com/nixos/nixpkgs/compare/3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f...4bc72cae107788bf3f24f30db2e2f685c9298dc9))__