### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688220547,
-        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
+        "lastModified": 1688853517,
+        "narHash": "sha256-oatIWiJI13an13XOX43pnKMRmqzQOUgF/IVNG73r8nA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
+        "rev": "e15010ee6e9bd356a6746ff9b9f9a9097ee8ddcf",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687279045,
-        "narHash": "sha256-LR0dsXd/A07M61jclyBUW0wRojEQteWReKM35zoJXp0=",
+        "lastModified": 1688393327,
+        "narHash": "sha256-UHibyCq4nbnbsNE1SL4p87mYn0PLoGNn1ULXrpLeTRA=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "a8486b5d191f11d571f15d80b6e265d1712d01cf",
+        "rev": "0982e9ab209aee459ed3331ab4eadbb4d8a023e1",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688049487,
-        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
+        "lastModified": 1688679045,
+        "narHash": "sha256-t3xGEfYIwhaLTPU8FLtN/pLPytNeDwbLI6a7XFFBlGo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
+        "rev": "3c7487575d9445185249a159046cc02ff364bff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/89d10f8adce369a80e046c2fd56d1e7b7507bb5b` →
  `github:nix-community/home-manager/e15010ee6e9bd356a6746ff9b9f9a9097ee8ddcf`
  __([view changes](https://github.com/nix-community/home-manager/compare/89d10f8adce369a80e046c2fd56d1e7b7507bb5b...e15010ee6e9bd356a6746ff9b9f9a9097ee8ddcf))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/a8486b5d191f11d571f15d80b6e265d1712d01cf` →
  `github:nix-community/NixOS-WSL/0982e9ab209aee459ed3331ab4eadbb4d8a023e1`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/a8486b5d191f11d571f15d80b6e265d1712d01cf...0982e9ab209aee459ed3331ab4eadbb4d8a023e1))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/4bc72cae107788bf3f24f30db2e2f685c9298dc9` →
  `github:nixos/nixpkgs/3c7487575d9445185249a159046cc02ff364bff8`
  __([view changes](https://github.com/nixos/nixpkgs/compare/4bc72cae107788bf3f24f30db2e2f685c9298dc9...3c7487575d9445185249a159046cc02ff364bff8))__