### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689447223,
-        "narHash": "sha256-A5vQBtWYamvGf3c2IEhAmwIkXBzuzrkpnMYbLvc+lEY=",
+        "lastModified": 1690027126,
+        "narHash": "sha256-DeUhQQxbu41Qn0uHyNazPBiTJ0lNsf26ThFopWBRRnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f5b03feb33629cb2b6dd513935637e8cc718a5ba",
+        "rev": "76dd6c66190db0d46ac6b3ca816cc17b581df42c",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689444953,
-        "narHash": "sha256-0o56bfb2LC38wrinPdCGLDScd77LVcr7CrH1zK7qvDg=",
+        "lastModified": 1690031011,
+        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8acef304efe70152463a6399f73e636bcc363813",
+        "rev": "12303c652b881435065a98729eb7278313041e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/f5b03feb33629cb2b6dd513935637e8cc718a5ba` →
  `github:nix-community/home-manager/76dd6c66190db0d46ac6b3ca816cc17b581df42c`
  __([view changes](https://github.com/nix-community/home-manager/compare/f5b03feb33629cb2b6dd513935637e8cc718a5ba...76dd6c66190db0d46ac6b3ca816cc17b581df42c))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/8acef304efe70152463a6399f73e636bcc363813` →
  `github:nixos/nixpkgs/12303c652b881435065a98729eb7278313041e49`
  __([view changes](https://github.com/nixos/nixpkgs/compare/8acef304efe70152463a6399f73e636bcc363813...12303c652b881435065a98729eb7278313041e49))__