### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690027126,
-        "narHash": "sha256-DeUhQQxbu41Qn0uHyNazPBiTJ0lNsf26ThFopWBRRnM=",
+        "lastModified": 1690652600,
+        "narHash": "sha256-Dy09g7mezToVwtFPyY25fAx1hzqNXv73/QmY5/qyR44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "76dd6c66190db0d46ac6b3ca816cc17b581df42c",
+        "rev": "f58889c07efa8e1328fdf93dc1796ec2a5c47f38",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689163449,
-        "narHash": "sha256-C/cm0fRoNGx00lDOieW5439jpBH9VRWRJcAOXUFy+zs=",
+        "lastModified": 1690553050,
+        "narHash": "sha256-pK3kF30OykL3v6P8UP6ipihlS34KoGq9SryCj3tHrFw=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "20a1f182aed3d2bbc72f62f5814fc3dd34a1cf0c",
+        "rev": "f7a95a37306c46b42e9ce751977c44c752fd5eca",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690031011,
-        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
+        "lastModified": 1690548937,
+        "narHash": "sha256-x3ZOPGLvtC0/+iFAg9Kvqm/8hTAIkGjc634SqtgaXTA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "12303c652b881435065a98729eb7278313041e49",
+        "rev": "2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/76dd6c66190db0d46ac6b3ca816cc17b581df42c` →
  `github:nix-community/home-manager/f58889c07efa8e1328fdf93dc1796ec2a5c47f38`
  __([view changes](https://github.com/nix-community/home-manager/compare/76dd6c66190db0d46ac6b3ca816cc17b581df42c...f58889c07efa8e1328fdf93dc1796ec2a5c47f38))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/20a1f182aed3d2bbc72f62f5814fc3dd34a1cf0c` →
  `github:nix-community/NixOS-WSL/f7a95a37306c46b42e9ce751977c44c752fd5eca`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/20a1f182aed3d2bbc72f62f5814fc3dd34a1cf0c...f7a95a37306c46b42e9ce751977c44c752fd5eca))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/12303c652b881435065a98729eb7278313041e49` →
  `github:nixos/nixpkgs/2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28`
  __([view changes](https://github.com/nixos/nixpkgs/compare/12303c652b881435065a98729eb7278313041e49...2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28))__