### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690652600,
-        "narHash": "sha256-Dy09g7mezToVwtFPyY25fAx1hzqNXv73/QmY5/qyR44=",
+        "lastModified": 1691225770,
+        "narHash": "sha256-O5slH8nW8msTAqVAS5rkvdHSkjmrO+JauuSDzZCmv2M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f58889c07efa8e1328fdf93dc1796ec2a5c47f38",
+        "rev": "0a014a729cdd54d9919ff36b714d047909d7a4c8",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690548937,
-        "narHash": "sha256-x3ZOPGLvtC0/+iFAg9Kvqm/8hTAIkGjc634SqtgaXTA=",
+        "lastModified": 1691186842,
+        "narHash": "sha256-wxBVCvZUwq+XS4N4t9NqsHV4E64cPVqQ2fdDISpjcw0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28",
+        "rev": "18036c0be90f4e308ae3ebcab0e14aae0336fe42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/f58889c07efa8e1328fdf93dc1796ec2a5c47f38` →
  `github:nix-community/home-manager/0a014a729cdd54d9919ff36b714d047909d7a4c8`
  __([view changes](https://github.com/nix-community/home-manager/compare/f58889c07efa8e1328fdf93dc1796ec2a5c47f38...0a014a729cdd54d9919ff36b714d047909d7a4c8))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28` →
  `github:nixos/nixpkgs/18036c0be90f4e308ae3ebcab0e14aae0336fe42`
  __([view changes](https://github.com/nixos/nixpkgs/compare/2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28...18036c0be90f4e308ae3ebcab0e14aae0336fe42))__