### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691225770,
-        "narHash": "sha256-O5slH8nW8msTAqVAS5rkvdHSkjmrO+JauuSDzZCmv2M=",
+        "lastModified": 1691856649,
+        "narHash": "sha256-1/KYCwNyOPpUoyno9Yj3zMHITQaW+wPzVlJFPOPPCo4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0a014a729cdd54d9919ff36b714d047909d7a4c8",
+        "rev": "406d34d919e9e8b831b531782cf5ef6995188566",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691186842,
-        "narHash": "sha256-wxBVCvZUwq+XS4N4t9NqsHV4E64cPVqQ2fdDISpjcw0=",
+        "lastModified": 1691654369,
+        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18036c0be90f4e308ae3ebcab0e14aae0336fe42",
+        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/0a014a729cdd54d9919ff36b714d047909d7a4c8` →
  `github:nix-community/home-manager/406d34d919e9e8b831b531782cf5ef6995188566`
  __([view changes](https://github.com/nix-community/home-manager/compare/0a014a729cdd54d9919ff36b714d047909d7a4c8...406d34d919e9e8b831b531782cf5ef6995188566))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/18036c0be90f4e308ae3ebcab0e14aae0336fe42` →
  `github:nixos/nixpkgs/ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e`
  __([view changes](https://github.com/nixos/nixpkgs/compare/18036c0be90f4e308ae3ebcab0e14aae0336fe42...ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e))__