### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691856649,
-        "narHash": "sha256-1/KYCwNyOPpUoyno9Yj3zMHITQaW+wPzVlJFPOPPCo4=",
+        "lastModified": 1692448348,
+        "narHash": "sha256-/Wy9Bzw59A5OD82S9dWHshg+wiSzJNh95hPXNhO5K7E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "406d34d919e9e8b831b531782cf5ef6995188566",
+        "rev": "bdb5bcad01ff7332fdcf4b128211e81905113f84",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691654369,
-        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/406d34d919e9e8b831b531782cf5ef6995188566` →
  `github:nix-community/home-manager/bdb5bcad01ff7332fdcf4b128211e81905113f84`
  __([view changes](https://github.com/nix-community/home-manager/compare/406d34d919e9e8b831b531782cf5ef6995188566...bdb5bcad01ff7332fdcf4b128211e81905113f84))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e` →
  `github:nixos/nixpkgs/d680ded26da5cf104dd2735a51e88d2d8f487b4d`
  __([view changes](https://github.com/nixos/nixpkgs/compare/ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e...d680ded26da5cf104dd2735a51e88d2d8f487b4d))__