### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692448348,
-        "narHash": "sha256-/Wy9Bzw59A5OD82S9dWHshg+wiSzJNh95hPXNhO5K7E=",
+        "lastModified": 1692763155,
+        "narHash": "sha256-qMrGKZ8c/q/mHO3ZdrcBPwiVVXPLLgXjY98Ejqb5kAA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bdb5bcad01ff7332fdcf4b128211e81905113f84",
+        "rev": "6a20e40acaebf067da682661aa67da8b36812606",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690553050,
-        "narHash": "sha256-pK3kF30OykL3v6P8UP6ipihlS34KoGq9SryCj3tHrFw=",
+        "lastModified": 1692543835,
+        "narHash": "sha256-1fR7+IhSSEHRbRW1w3nXb38/4kFfpmCDzMsK+ApqZCk=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "f7a95a37306c46b42e9ce751977c44c752fd5eca",
+        "rev": "faab3194692c5b6b351e33fc8d5e7f15f22d1d15",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692447944,
-        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
+        "lastModified": 1693003285,
+        "narHash": "sha256-5nm4yrEHKupjn62MibENtfqlP6pWcRTuSKrMiH9bLkc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
+        "rev": "5690c4271f2998c304a45c91a0aeb8fb69feaea7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/919d646de7be200f3bf08cb76ae1f09402b6f9b4` →
  `github:numtide/flake-utils/f9e7cf818399d17d347f847525c5a5a8032e4e44`
  __([view changes](https://github.com/numtide/flake-utils/compare/919d646de7be200f3bf08cb76ae1f09402b6f9b4...f9e7cf818399d17d347f847525c5a5a8032e4e44))__
* __home-manager:__ 
  `github:nix-community/home-manager/bdb5bcad01ff7332fdcf4b128211e81905113f84` →
  `github:nix-community/home-manager/6a20e40acaebf067da682661aa67da8b36812606`
  __([view changes](https://github.com/nix-community/home-manager/compare/bdb5bcad01ff7332fdcf4b128211e81905113f84...6a20e40acaebf067da682661aa67da8b36812606))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/f7a95a37306c46b42e9ce751977c44c752fd5eca` →
  `github:nix-community/NixOS-WSL/faab3194692c5b6b351e33fc8d5e7f15f22d1d15`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/f7a95a37306c46b42e9ce751977c44c752fd5eca...faab3194692c5b6b351e33fc8d5e7f15f22d1d15))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/d680ded26da5cf104dd2735a51e88d2d8f487b4d` →
  `github:nixos/nixpkgs/5690c4271f2998c304a45c91a0aeb8fb69feaea7`
  __([view changes](https://github.com/nixos/nixpkgs/compare/d680ded26da5cf104dd2735a51e88d2d8f487b4d...5690c4271f2998c304a45c91a0aeb8fb69feaea7))__