### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692763155,
-        "narHash": "sha256-qMrGKZ8c/q/mHO3ZdrcBPwiVVXPLLgXjY98Ejqb5kAA=",
+        "lastModified": 1693646047,
+        "narHash": "sha256-VsuXtCGOhrzp1qb1CSoV/cO+5f+GPtA4J/SFYqqLyfo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a20e40acaebf067da682661aa67da8b36812606",
+        "rev": "fae8af43e201a8929ce45a5ea46192bbd1ffff18",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693003285,
-        "narHash": "sha256-5nm4yrEHKupjn62MibENtfqlP6pWcRTuSKrMiH9bLkc=",
+        "lastModified": 1693565476,
+        "narHash": "sha256-ya00zHt7YbPo3ve/wNZ/6nts61xt7wK/APa6aZAfey0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5690c4271f2998c304a45c91a0aeb8fb69feaea7",
+        "rev": "aa8aa7e2ea35ce655297e8322dc82bf77a31d04b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/6a20e40acaebf067da682661aa67da8b36812606` →
  `github:nix-community/home-manager/fae8af43e201a8929ce45a5ea46192bbd1ffff18`
  __([view changes](https://github.com/nix-community/home-manager/compare/6a20e40acaebf067da682661aa67da8b36812606...fae8af43e201a8929ce45a5ea46192bbd1ffff18))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5690c4271f2998c304a45c91a0aeb8fb69feaea7` →
  `github:nixos/nixpkgs/aa8aa7e2ea35ce655297e8322dc82bf77a31d04b`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5690c4271f2998c304a45c91a0aeb8fb69feaea7...aa8aa7e2ea35ce655297e8322dc82bf77a31d04b))__