### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693646047,
-        "narHash": "sha256-VsuXtCGOhrzp1qb1CSoV/cO+5f+GPtA4J/SFYqqLyfo=",
+        "lastModified": 1694375657,
+        "narHash": "sha256-32X8dcty4vPXx+D4yJPQZBo5hJ1NQikALhevGv6elO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fae8af43e201a8929ce45a5ea46192bbd1ffff18",
+        "rev": "f7848d3e5f15ed02e3f286029697e41ee31662d7",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692543835,
-        "narHash": "sha256-1fR7+IhSSEHRbRW1w3nXb38/4kFfpmCDzMsK+ApqZCk=",
+        "lastModified": 1694339281,
+        "narHash": "sha256-0wdDtsl9jBxW8ld2+1SwD12OzpcmEha0KsgoFGlz+P8=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "faab3194692c5b6b351e33fc8d5e7f15f22d1d15",
+        "rev": "212e2d6b0d820fc9f1e79f7b5feeea2824db51bb",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693565476,
-        "narHash": "sha256-ya00zHt7YbPo3ve/wNZ/6nts61xt7wK/APa6aZAfey0=",
+        "lastModified": 1694183432,
+        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aa8aa7e2ea35ce655297e8322dc82bf77a31d04b",
+        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/fae8af43e201a8929ce45a5ea46192bbd1ffff18` →
  `github:nix-community/home-manager/f7848d3e5f15ed02e3f286029697e41ee31662d7`
  __([view changes](https://github.com/nix-community/home-manager/compare/fae8af43e201a8929ce45a5ea46192bbd1ffff18...f7848d3e5f15ed02e3f286029697e41ee31662d7))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/faab3194692c5b6b351e33fc8d5e7f15f22d1d15` →
  `github:nix-community/NixOS-WSL/212e2d6b0d820fc9f1e79f7b5feeea2824db51bb`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/faab3194692c5b6b351e33fc8d5e7f15f22d1d15...212e2d6b0d820fc9f1e79f7b5feeea2824db51bb))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/aa8aa7e2ea35ce655297e8322dc82bf77a31d04b` →
  `github:nixos/nixpkgs/db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b`
  __([view changes](https://github.com/nixos/nixpkgs/compare/aa8aa7e2ea35ce655297e8322dc82bf77a31d04b...db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b))__