### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694375657,
-        "narHash": "sha256-32X8dcty4vPXx+D4yJPQZBo5hJ1NQikALhevGv6elO4=",
+        "lastModified": 1695509808,
+        "narHash": "sha256-rW6kfjLLYDB9xGJwoFkSNzcmLJCcN7VcD+YnDPbEM2c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f7848d3e5f15ed02e3f286029697e41ee31662d7",
+        "rev": "2d27bdcd640759a5fb1b48125fee7280adad95f7",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694339281,
-        "narHash": "sha256-0wdDtsl9jBxW8ld2+1SwD12OzpcmEha0KsgoFGlz+P8=",
+        "lastModified": 1694522206,
+        "narHash": "sha256-mb34WlyHi/whE6gIMEtXKfGRALzvB6/U7CYdUnJKN+c=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "212e2d6b0d820fc9f1e79f7b5feeea2824db51bb",
+        "rev": "e7d93d0f478b6fbb47c00d03449dc3d08b90abb7",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694183432,
-        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
+        "lastModified": 1695360818,
+        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
+        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/f9e7cf818399d17d347f847525c5a5a8032e4e44` →
  `github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384`
  __([view changes](https://github.com/numtide/flake-utils/compare/f9e7cf818399d17d347f847525c5a5a8032e4e44...ff7b65b44d01cf9ba6a71320833626af21126384))__
* __home-manager:__ 
  `github:nix-community/home-manager/f7848d3e5f15ed02e3f286029697e41ee31662d7` →
  `github:nix-community/home-manager/2d27bdcd640759a5fb1b48125fee7280adad95f7`
  __([view changes](https://github.com/nix-community/home-manager/compare/f7848d3e5f15ed02e3f286029697e41ee31662d7...2d27bdcd640759a5fb1b48125fee7280adad95f7))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/212e2d6b0d820fc9f1e79f7b5feeea2824db51bb` →
  `github:nix-community/NixOS-WSL/e7d93d0f478b6fbb47c00d03449dc3d08b90abb7`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/212e2d6b0d820fc9f1e79f7b5feeea2824db51bb...e7d93d0f478b6fbb47c00d03449dc3d08b90abb7))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b` →
  `github:nixos/nixpkgs/e35dcc04a3853da485a396bdd332217d0ac9054f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b...e35dcc04a3853da485a396bdd332217d0ac9054f))__