### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695509808,
-        "narHash": "sha256-rW6kfjLLYDB9xGJwoFkSNzcmLJCcN7VcD+YnDPbEM2c=",
+        "lastModified": 1696063111,
+        "narHash": "sha256-F2IJEbyH3xG0eqyAYn9JoV+niqNz+xb4HICYNkkviNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d27bdcd640759a5fb1b48125fee7280adad95f7",
+        "rev": "ae896c810f501bf0c3a2fd7fc2de094dd0addf01",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694522206,
-        "narHash": "sha256-mb34WlyHi/whE6gIMEtXKfGRALzvB6/U7CYdUnJKN+c=",
+        "lastModified": 1696053802,
+        "narHash": "sha256-8TTbJbtGDz1MstExrVQe56eXZpovvZv6G6L6q/4NOKg=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "e7d93d0f478b6fbb47c00d03449dc3d08b90abb7",
+        "rev": "cadde47d123d1a534c272b04a7582f1d11474c48",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695360818,
-        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
+        "lastModified": 1695830400,
+        "narHash": "sha256-gToZXQVr0G/1WriO83olnqrLSHF2Jb8BPcmCt497ro0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
+        "rev": "8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/2d27bdcd640759a5fb1b48125fee7280adad95f7` →
  `github:nix-community/home-manager/ae896c810f501bf0c3a2fd7fc2de094dd0addf01`
  __([view changes](https://github.com/nix-community/home-manager/compare/2d27bdcd640759a5fb1b48125fee7280adad95f7...ae896c810f501bf0c3a2fd7fc2de094dd0addf01))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/e7d93d0f478b6fbb47c00d03449dc3d08b90abb7` →
  `github:nix-community/NixOS-WSL/cadde47d123d1a534c272b04a7582f1d11474c48`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/e7d93d0f478b6fbb47c00d03449dc3d08b90abb7...cadde47d123d1a534c272b04a7582f1d11474c48))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/e35dcc04a3853da485a396bdd332217d0ac9054f` →
  `github:nixos/nixpkgs/8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2`
  __([view changes](https://github.com/nixos/nixpkgs/compare/e35dcc04a3853da485a396bdd332217d0ac9054f...8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2))__