### PR TITLE
build(deps): bump flake inputs `flake-compat`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696063111,
-        "narHash": "sha256-F2IJEbyH3xG0eqyAYn9JoV+niqNz+xb4HICYNkkviNI=",
+        "lastModified": 1696737557,
+        "narHash": "sha256-YD/pjDjj/BNmisEvRdM/vspkCU3xyyeGVAUWhvVSi5Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ae896c810f501bf0c3a2fd7fc2de094dd0addf01",
+        "rev": "3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696053802,
-        "narHash": "sha256-8TTbJbtGDz1MstExrVQe56eXZpovvZv6G6L6q/4NOKg=",
+        "lastModified": 1696239710,
+        "narHash": "sha256-Ps7zIKYGT7TEi9JrG1fV9cdUY5X6hmaidUcTaEDxPO4=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "cadde47d123d1a534c272b04a7582f1d11474c48",
+        "rev": "337edef90c8abe35b42e95aecf510a063dad02dd",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695830400,
-        "narHash": "sha256-gToZXQVr0G/1WriO83olnqrLSHF2Jb8BPcmCt497ro0=",
+        "lastModified": 1696604326,
+        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2",
+        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-compat:__ 
  `github:edolstra/flake-compat/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9` →
  `github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33`
  __([view changes](https://github.com/edolstra/flake-compat/compare/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9...0f9255e01c2351cc7d116c072cb317785dd33b33))__
* __home-manager:__ 
  `github:nix-community/home-manager/ae896c810f501bf0c3a2fd7fc2de094dd0addf01` →
  `github:nix-community/home-manager/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d`
  __([view changes](https://github.com/nix-community/home-manager/compare/ae896c810f501bf0c3a2fd7fc2de094dd0addf01...3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/cadde47d123d1a534c272b04a7582f1d11474c48` →
  `github:nix-community/NixOS-WSL/337edef90c8abe35b42e95aecf510a063dad02dd`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/cadde47d123d1a534c272b04a7582f1d11474c48...337edef90c8abe35b42e95aecf510a063dad02dd))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2` →
  `github:nixos/nixpkgs/87828a0e03d1418e848d3dd3f3014a632e4a4f64`
  __([view changes](https://github.com/nixos/nixpkgs/compare/8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2...87828a0e03d1418e848d3dd3f3014a632e4a4f64))__