### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696737557,
-        "narHash": "sha256-YD/pjDjj/BNmisEvRdM/vspkCU3xyyeGVAUWhvVSi5Y=",
+        "lastModified": 1697323135,
+        "narHash": "sha256-tlAv11c0NIRTk2IzpFxYknHrveeFXojVyCTAMg749Zg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d",
+        "rev": "d4a5076ea8c2c063c45e0165f9f75f69ef583e20",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696239710,
-        "narHash": "sha256-Ps7zIKYGT7TEi9JrG1fV9cdUY5X6hmaidUcTaEDxPO4=",
+        "lastModified": 1696883888,
+        "narHash": "sha256-EdQMeJxDoi26YDtkNf20mNBeCj7Y5eKg+rrxkiB86z0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "337edef90c8abe35b42e95aecf510a063dad02dd",
+        "rev": "5da7c4fd0ab9693d83cae50de7d9430696f92568",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696604326,
-        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
+        "lastModified": 1697059129,
+        "narHash": "sha256-9NJcFF9CEYPvHJ5ckE8kvINvI84SZZ87PvqMbH6pro0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
+        "rev": "5e4c2ada4fcd54b99d56d7bd62f384511a7e2593",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d` →
  `github:nix-community/home-manager/d4a5076ea8c2c063c45e0165f9f75f69ef583e20`
  __([view changes](https://github.com/nix-community/home-manager/compare/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d...d4a5076ea8c2c063c45e0165f9f75f69ef583e20))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/337edef90c8abe35b42e95aecf510a063dad02dd` →
  `github:nix-community/NixOS-WSL/5da7c4fd0ab9693d83cae50de7d9430696f92568`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/337edef90c8abe35b42e95aecf510a063dad02dd...5da7c4fd0ab9693d83cae50de7d9430696f92568))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/87828a0e03d1418e848d3dd3f3014a632e4a4f64` →
  `github:nixos/nixpkgs/5e4c2ada4fcd54b99d56d7bd62f384511a7e2593`
  __([view changes](https://github.com/nixos/nixpkgs/compare/87828a0e03d1418e848d3dd3f3014a632e4a4f64...5e4c2ada4fcd54b99d56d7bd62f384511a7e2593))__