### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698479159,
-        "narHash": "sha256-rJHBDwW4LbADEfhkgGHjKGfL2dF44NrlyXdXeZrQahs=",
+        "lastModified": 1699748018,
+        "narHash": "sha256-28rwXnxgscLkeII6wj44cuP6RuiynhzZSa424ZwGt/s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f92a54fef4eacdbe86b0a2054054dd58b0e2a2a4",
+        "rev": "50e582b9f91e409ffd2e134017445d376659b32e",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698222534,
-        "narHash": "sha256-iF9C7C7eT8LVVWx5IOZ/8KKJT8AIw9A5aBA6vqS18l8=",
+        "lastModified": 1699549513,
+        "narHash": "sha256-cfsghOs6Cr61wFsxkWonK8AwPwHaRGZ6QkbasUgygh4=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "a058cff4b09b3a398d8caa379b4dc96cfedd98c9",
+        "rev": "0e4c17efebff955471f169fffbb7e8cd62ada498",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1699099776,
+        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/f92a54fef4eacdbe86b0a2054054dd58b0e2a2a4` →
  `github:nix-community/home-manager/50e582b9f91e409ffd2e134017445d376659b32e`
  __([view changes](https://github.com/nix-community/home-manager/compare/f92a54fef4eacdbe86b0a2054054dd58b0e2a2a4...50e582b9f91e409ffd2e134017445d376659b32e))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/a058cff4b09b3a398d8caa379b4dc96cfedd98c9` →
  `github:nix-community/NixOS-WSL/0e4c17efebff955471f169fffbb7e8cd62ada498`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/a058cff4b09b3a398d8caa379b4dc96cfedd98c9...0e4c17efebff955471f169fffbb7e8cd62ada498))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/63678e9f3d3afecfeafa0acead6239cdb447574c` →
  `github:nixos/nixpkgs/85f1ba3e51676fa8cc604a3d863d729026a6b8eb`
  __([view changes](https://github.com/nixos/nixpkgs/compare/63678e9f3d3afecfeafa0acead6239cdb447574c...85f1ba3e51676fa8cc604a3d863d729026a6b8eb))__