### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702159252,
-        "narHash": "sha256-4mYOL1EhOmt92OtYsHXRViWrSHvR5obLfCllMmQsUzY=",
+        "lastModified": 1702735279,
+        "narHash": "sha256-SztEzDOE/6bDNnWWvnRbSHPVrgewLwdSei1sxoZFejM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6b7303bd149723c57ca23f5a9428482d6b07306",
+        "rev": "e9b9ecef4295a835ab073814f100498716b05a96",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701722881,
-        "narHash": "sha256-Wim+dqT6W6nTdifu/jmToIzD7eCQaCEhDqDp5kexyfM=",
+        "lastModified": 1702728584,
+        "narHash": "sha256-KOfJihF3QRVjakvLg+JeK6B0raexiiI0ib2TY3Ve+eQ=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "5ee4fa3515de7b5609e6d161b800d91328a7a143",
+        "rev": "092b4239169477b6e785ae22db56318439351315",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701718080,
-        "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
+        "lastModified": 1702312524,
+        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c7f3c0fb7c08a0814627611d9d7d45ab6d75335",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/e6b7303bd149723c57ca23f5a9428482d6b07306` →
  `github:nix-community/home-manager/e9b9ecef4295a835ab073814f100498716b05a96`
  __([view changes](https://github.com/nix-community/home-manager/compare/e6b7303bd149723c57ca23f5a9428482d6b07306...e9b9ecef4295a835ab073814f100498716b05a96))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/5ee4fa3515de7b5609e6d161b800d91328a7a143` →
  `github:nix-community/NixOS-WSL/092b4239169477b6e785ae22db56318439351315`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/5ee4fa3515de7b5609e6d161b800d91328a7a143...092b4239169477b6e785ae22db56318439351315))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/2c7f3c0fb7c08a0814627611d9d7d45ab6d75335` →
  `github:nixos/nixpkgs/a9bf124c46ef298113270b1f84a164865987a91c`
  __([view changes](https://github.com/nixos/nixpkgs/compare/2c7f3c0fb7c08a0814627611d9d7d45ab6d75335...a9bf124c46ef298113270b1f84a164865987a91c))__