### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703368619,
-        "narHash": "sha256-ZGPMYL7FMA6enhuwby961bBANmoFX14EA86m2/Jw5Jo=",
+        "lastModified": 1703838268,
+        "narHash": "sha256-SRg5nXcdPnrsQR2MTAp7en0NyJnQ2wB1ivmsgEbvN+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a2523ea0343b056ba240abbac90ab5f116a7aa7b",
+        "rev": "2aff324cf65f5f98f89d878c056b779466b17db8",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703211095,
-        "narHash": "sha256-Mne3a6cP3XJrWxrCXtz5XkfC+9NQsMV/QpOESvjKt6c=",
+        "lastModified": 1703991017,
+        "narHash": "sha256-5wlJYAktFeHJlQt9VubO0FjaLe+96A/N3Die5Ym5Y/E=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "04816e47a012515f45a2e5d491a558b538806d74",
+        "rev": "c1c843e5059d942092d9bb9dc93768e5d2d79bdc",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703255338,
-        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
+        "lastModified": 1703637592,
+        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
+        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/a2523ea0343b056ba240abbac90ab5f116a7aa7b` →
  `github:nix-community/home-manager/2aff324cf65f5f98f89d878c056b779466b17db8`
  __([view changes](https://github.com/nix-community/home-manager/compare/a2523ea0343b056ba240abbac90ab5f116a7aa7b...2aff324cf65f5f98f89d878c056b779466b17db8))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/04816e47a012515f45a2e5d491a558b538806d74` →
  `github:nix-community/NixOS-WSL/c1c843e5059d942092d9bb9dc93768e5d2d79bdc`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/04816e47a012515f45a2e5d491a558b538806d74...c1c843e5059d942092d9bb9dc93768e5d2d79bdc))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/6df37dc6a77654682fe9f071c62b4242b5342e04` →
  `github:nixos/nixpkgs/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8`
  __([view changes](https://github.com/nixos/nixpkgs/compare/6df37dc6a77654682fe9f071c62b4242b5342e04...cfc3698c31b1fb9cdcf10f36c9643460264d0ca8))__