### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703838268,
-        "narHash": "sha256-SRg5nXcdPnrsQR2MTAp7en0NyJnQ2wB1ivmsgEbvN+o=",
+        "lastModified": 1705169127,
+        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2aff324cf65f5f98f89d878c056b779466b17db8",
+        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703991017,
-        "narHash": "sha256-5wlJYAktFeHJlQt9VubO0FjaLe+96A/N3Die5Ym5Y/E=",
+        "lastModified": 1705003621,
+        "narHash": "sha256-bnQKeNbNYyKfmJN2/KD+t8gDKA0uU8Ak4/sV4gvlA2E=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "c1c843e5059d942092d9bb9dc93768e5d2d79bdc",
+        "rev": "0fa9268bf9a903498cb567e6d4d01eb945f36f6e",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "lastModified": 1704722960,
+        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/2aff324cf65f5f98f89d878c056b779466b17db8` →
  `github:nix-community/home-manager/f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8`
  __([view changes](https://github.com/nix-community/home-manager/compare/2aff324cf65f5f98f89d878c056b779466b17db8...f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/c1c843e5059d942092d9bb9dc93768e5d2d79bdc` →
  `github:nix-community/NixOS-WSL/0fa9268bf9a903498cb567e6d4d01eb945f36f6e`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/c1c843e5059d942092d9bb9dc93768e5d2d79bdc...0fa9268bf9a903498cb567e6d4d01eb945f36f6e))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8` →
  `github:nixos/nixpkgs/317484b1ead87b9c1b8ac5261a8d2dd748a0492d`
  __([view changes](https://github.com/nixos/nixpkgs/compare/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8...317484b1ead87b9c1b8ac5261a8d2dd748a0492d))__