### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705169127,
-        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
+        "lastModified": 1705794055,
+        "narHash": "sha256-mv/KrxEAZNhpPJcDqdQ709If9p2DTEYIDPo2r9xchlg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
+        "rev": "9b378afae72cb07471e19aefc30e8e05ef2d7a61",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705003621,
-        "narHash": "sha256-bnQKeNbNYyKfmJN2/KD+t8gDKA0uU8Ak4/sV4gvlA2E=",
+        "lastModified": 1705359964,
+        "narHash": "sha256-ys1MDjIH6z5UP7gAciRfUAlf2FJV0t3yFib965N/S+I=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "0fa9268bf9a903498cb567e6d4d01eb945f36f6e",
+        "rev": "bb3eeeb96ce059ae29309138874ccf58e796f4b1",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704722960,
-        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
+        "lastModified": 1705677747,
+        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
+        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725` →
  `github:numtide/flake-utils/1ef2e671c3b0c19053962c07dbda38332dcebf26`
  __([view changes](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...1ef2e671c3b0c19053962c07dbda38332dcebf26))__
* __home-manager:__ 
  `github:nix-community/home-manager/f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8` →
  `github:nix-community/home-manager/9b378afae72cb07471e19aefc30e8e05ef2d7a61`
  __([view changes](https://github.com/nix-community/home-manager/compare/f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8...9b378afae72cb07471e19aefc30e8e05ef2d7a61))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/0fa9268bf9a903498cb567e6d4d01eb945f36f6e` →
  `github:nix-community/NixOS-WSL/bb3eeeb96ce059ae29309138874ccf58e796f4b1`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/0fa9268bf9a903498cb567e6d4d01eb945f36f6e...bb3eeeb96ce059ae29309138874ccf58e796f4b1))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/317484b1ead87b9c1b8ac5261a8d2dd748a0492d` →
  `github:nixos/nixpkgs/bbe7d8f876fbbe7c959c90ba2ae2852220573261`
  __([view changes](https://github.com/nixos/nixpkgs/compare/317484b1ead87b9c1b8ac5261a8d2dd748a0492d...bbe7d8f876fbbe7c959c90ba2ae2852220573261))__