### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705794055,
-        "narHash": "sha256-mv/KrxEAZNhpPJcDqdQ709If9p2DTEYIDPo2r9xchlg=",
+        "lastModified": 1706985585,
+        "narHash": "sha256-ptshv4qXiC6V0GCfpABz88UGGPNwqs5tAxaRUKbk1Qo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b378afae72cb07471e19aefc30e8e05ef2d7a61",
+        "rev": "1ca210648a6ca9b957efde5da957f3de6b1f0c45",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705359964,
-        "narHash": "sha256-ys1MDjIH6z5UP7gAciRfUAlf2FJV0t3yFib965N/S+I=",
+        "lastModified": 1706867893,
+        "narHash": "sha256-c5bADvtL35S3vsJaXR5YWTXe08W0gSwOrTOXfpJB4Ac=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "bb3eeeb96ce059ae29309138874ccf58e796f4b1",
+        "rev": "bcae8dc73b931b7f0fc65f1f1ef93dc379dfd66b",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705677747,
-        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
+        "lastModified": 1706732774,
+        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
+        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/9b378afae72cb07471e19aefc30e8e05ef2d7a61` →
  `github:nix-community/home-manager/1ca210648a6ca9b957efde5da957f3de6b1f0c45`
  __([view changes](https://github.com/nix-community/home-manager/compare/9b378afae72cb07471e19aefc30e8e05ef2d7a61...1ca210648a6ca9b957efde5da957f3de6b1f0c45))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/bb3eeeb96ce059ae29309138874ccf58e796f4b1` →
  `github:nix-community/NixOS-WSL/bcae8dc73b931b7f0fc65f1f1ef93dc379dfd66b`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/bb3eeeb96ce059ae29309138874ccf58e796f4b1...bcae8dc73b931b7f0fc65f1f1ef93dc379dfd66b))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/bbe7d8f876fbbe7c959c90ba2ae2852220573261` →
  `github:nixos/nixpkgs/b8b232ae7b8b144397fdb12d20f592e5e7c1a64d`
  __([view changes](https://github.com/nixos/nixpkgs/compare/bbe7d8f876fbbe7c959c90ba2ae2852220573261...b8b232ae7b8b144397fdb12d20f592e5e7c1a64d))__