### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706985585,
-        "narHash": "sha256-ptshv4qXiC6V0GCfpABz88UGGPNwqs5tAxaRUKbk1Qo=",
+        "lastModified": 1707607386,
+        "narHash": "sha256-hj/RgQMTvCWQVInkZwiMMieumkfOjHXhtWhfuXHop/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ca210648a6ca9b957efde5da957f3de6b1f0c45",
+        "rev": "bfd0ae29a86eff4603098683b516c67e22184511",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706867893,
-        "narHash": "sha256-c5bADvtL35S3vsJaXR5YWTXe08W0gSwOrTOXfpJB4Ac=",
+        "lastModified": 1707476384,
+        "narHash": "sha256-9YortZTCO9r7wFHX92t+npUDmD5VcKrkVmwaPCvEiXI=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "bcae8dc73b931b7f0fc65f1f1ef93dc379dfd66b",
+        "rev": "76ca59d8d4423b27c0238bc31401692ebc571365",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706732774,
-        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
+        "lastModified": 1707268954,
+        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
+        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/1ca210648a6ca9b957efde5da957f3de6b1f0c45` →
  `github:nix-community/home-manager/bfd0ae29a86eff4603098683b516c67e22184511`
  __([view changes](https://github.com/nix-community/home-manager/compare/1ca210648a6ca9b957efde5da957f3de6b1f0c45...bfd0ae29a86eff4603098683b516c67e22184511))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/bcae8dc73b931b7f0fc65f1f1ef93dc379dfd66b` →
  `github:nix-community/NixOS-WSL/76ca59d8d4423b27c0238bc31401692ebc571365`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/bcae8dc73b931b7f0fc65f1f1ef93dc379dfd66b...76ca59d8d4423b27c0238bc31401692ebc571365))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/b8b232ae7b8b144397fdb12d20f592e5e7c1a64d` →
  `github:nixos/nixpkgs/f8e2ebd66d097614d51a56a755450d4ae1632df1`
  __([view changes](https://github.com/nixos/nixpkgs/compare/b8b232ae7b8b144397fdb12d20f592e5e7c1a64d...f8e2ebd66d097614d51a56a755450d4ae1632df1))__