### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707607386,
-        "narHash": "sha256-hj/RgQMTvCWQVInkZwiMMieumkfOjHXhtWhfuXHop/8=",
+        "lastModified": 1708031129,
+        "narHash": "sha256-EH20hJfNnc1/ODdDVat9B7aKm0B95L3YtkIRwKLvQG8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bfd0ae29a86eff4603098683b516c67e22184511",
+        "rev": "3d6791b3897b526c82920a2ab5f61d71985b3cf8",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707476384,
-        "narHash": "sha256-9YortZTCO9r7wFHX92t+npUDmD5VcKrkVmwaPCvEiXI=",
+        "lastModified": 1707761607,
+        "narHash": "sha256-OKNdTgnyhZpmqdgba8s78/QvowyTIMJDp0iLxv570bU=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "76ca59d8d4423b27c0238bc31401692ebc571365",
+        "rev": "c8ddba82ca6b791be1acaae4b336ff8e857ec70b",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707268954,
-        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
+        "lastModified": 1708118438,
+        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
+        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/bfd0ae29a86eff4603098683b516c67e22184511` →
  `github:nix-community/home-manager/3d6791b3897b526c82920a2ab5f61d71985b3cf8`
  __([view changes](https://github.com/nix-community/home-manager/compare/bfd0ae29a86eff4603098683b516c67e22184511...3d6791b3897b526c82920a2ab5f61d71985b3cf8))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/76ca59d8d4423b27c0238bc31401692ebc571365` →
  `github:nix-community/NixOS-WSL/c8ddba82ca6b791be1acaae4b336ff8e857ec70b`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/76ca59d8d4423b27c0238bc31401692ebc571365...c8ddba82ca6b791be1acaae4b336ff8e857ec70b))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/f8e2ebd66d097614d51a56a755450d4ae1632df1` →
  `github:nixos/nixpkgs/5863c27340ba4de8f83e7e3c023b9599c3cb3c80`
  __([view changes](https://github.com/nixos/nixpkgs/compare/f8e2ebd66d097614d51a56a755450d4ae1632df1...5863c27340ba4de8f83e7e3c023b9599c3cb3c80))__