### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708031129,
-        "narHash": "sha256-EH20hJfNnc1/ODdDVat9B7aKm0B95L3YtkIRwKLvQG8=",
+        "lastModified": 1708806879,
+        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d6791b3897b526c82920a2ab5f61d71985b3cf8",
+        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707761607,
-        "narHash": "sha256-OKNdTgnyhZpmqdgba8s78/QvowyTIMJDp0iLxv570bU=",
+        "lastModified": 1708788887,
+        "narHash": "sha256-4HprTKLKiY8rXmthsuRAwXHW7hGaXsSlzmbXSWdOa7g=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "c8ddba82ca6b791be1acaae4b336ff8e857ec70b",
+        "rev": "7e3fc6a99a2c9e6701e2e0d37f1755e29a798b91",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708118438,
-        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
+        "lastModified": 1708655239,
+        "narHash": "sha256-ZrP/yACUvDB+zbqYJsln4iwotbH6CTZiTkANJ0AgDv4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
+        "rev": "cbc4211f0afffe6dfd2478a62615dd5175a13f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/3d6791b3897b526c82920a2ab5f61d71985b3cf8` →
  `github:nix-community/home-manager/4ee704cb13a5a7645436f400b9acc89a67b9c08a`
  __([view changes](https://github.com/nix-community/home-manager/compare/3d6791b3897b526c82920a2ab5f61d71985b3cf8...4ee704cb13a5a7645436f400b9acc89a67b9c08a))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/c8ddba82ca6b791be1acaae4b336ff8e857ec70b` →
  `github:nix-community/NixOS-WSL/7e3fc6a99a2c9e6701e2e0d37f1755e29a798b91`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/c8ddba82ca6b791be1acaae4b336ff8e857ec70b...7e3fc6a99a2c9e6701e2e0d37f1755e29a798b91))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5863c27340ba4de8f83e7e3c023b9599c3cb3c80` →
  `github:nixos/nixpkgs/cbc4211f0afffe6dfd2478a62615dd5175a13f9a`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5863c27340ba4de8f83e7e3c023b9599c3cb3c80...cbc4211f0afffe6dfd2478a62615dd5175a13f9a))__