### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708806879,
-        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
+        "lastModified": 1709445365,
+        "narHash": "sha256-DVv6nd9FQBbMWbOmhq0KVqmlc3y3FMSYl49UXmMcO+0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
+        "rev": "4de84265d7ec7634a69ba75028696d74de9a44a7",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708788887,
-        "narHash": "sha256-4HprTKLKiY8rXmthsuRAwXHW7hGaXsSlzmbXSWdOa7g=",
+        "lastModified": 1709211223,
+        "narHash": "sha256-1cjd+yXbTlnCwNwEDjn289rJ2f0er5M8pOig4PxniEM=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "7e3fc6a99a2c9e6701e2e0d37f1755e29a798b91",
+        "rev": "3257ad7f173b0314c8a42fec450fa6556495b97c",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708655239,
-        "narHash": "sha256-ZrP/yACUvDB+zbqYJsln4iwotbH6CTZiTkANJ0AgDv4=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbc4211f0afffe6dfd2478a62615dd5175a13f9a",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/1ef2e671c3b0c19053962c07dbda38332dcebf26` →
  `github:numtide/flake-utils/d465f4819400de7c8d874d50b982301f28a84605`
  __([view changes](https://github.com/numtide/flake-utils/compare/1ef2e671c3b0c19053962c07dbda38332dcebf26...d465f4819400de7c8d874d50b982301f28a84605))__
* __home-manager:__ 
  `github:nix-community/home-manager/4ee704cb13a5a7645436f400b9acc89a67b9c08a` →
  `github:nix-community/home-manager/4de84265d7ec7634a69ba75028696d74de9a44a7`
  __([view changes](https://github.com/nix-community/home-manager/compare/4ee704cb13a5a7645436f400b9acc89a67b9c08a...4de84265d7ec7634a69ba75028696d74de9a44a7))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/7e3fc6a99a2c9e6701e2e0d37f1755e29a798b91` →
  `github:nix-community/NixOS-WSL/3257ad7f173b0314c8a42fec450fa6556495b97c`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/7e3fc6a99a2c9e6701e2e0d37f1755e29a798b91...3257ad7f173b0314c8a42fec450fa6556495b97c))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/cbc4211f0afffe6dfd2478a62615dd5175a13f9a` →
  `github:nixos/nixpkgs/1536926ef5621b09bba54035ae2bb6d806d72ac8`
  __([view changes](https://github.com/nixos/nixpkgs/compare/cbc4211f0afffe6dfd2478a62615dd5175a13f9a...1536926ef5621b09bba54035ae2bb6d806d72ac8))__