### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`, `vscode-server`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709445365,
-        "narHash": "sha256-DVv6nd9FQBbMWbOmhq0KVqmlc3y3FMSYl49UXmMcO+0=",
+        "lastModified": 1710043165,
+        "narHash": "sha256-R34OB9q1JMqbIQlnuccWFGDYG0sWEALHxjL6kQGVR44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4de84265d7ec7634a69ba75028696d74de9a44a7",
+        "rev": "fbec89838763831bd92e1b09222dc9477942930f",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709211223,
-        "narHash": "sha256-1cjd+yXbTlnCwNwEDjn289rJ2f0er5M8pOig4PxniEM=",
+        "lastModified": 1709980437,
+        "narHash": "sha256-rp1MwfRaZl7TPM4E5i1HxQGJCCfMcIa7dOzTX3SW7ro=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "3257ad7f173b0314c8a42fec450fa6556495b97c",
+        "rev": "e0b9e6c8ff35c7a28cb6baa02d85a9737a2ee4e9",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709237383,
-        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684517665,
-        "narHash": "sha256-SaAr66uCQ8CF75jIr23FZjk1+9Kfwm5sQnwV25206Gs=",
+        "lastModified": 1709622318,
+        "narHash": "sha256-bTscF0366xtoIXgH7Zq+Mn0mpX3w4h/2xKpHiYMyLNc=",
         "owner": "msteen",
         "repo": "nixos-vscode-server",
-        "rev": "1e1358493df6529d4c7bc4cc3066f76fd16d4ae6",
+        "rev": "d0ed9b8cf1f0a71f110df9119489ab047e0726bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/4de84265d7ec7634a69ba75028696d74de9a44a7` →
  `github:nix-community/home-manager/fbec89838763831bd92e1b09222dc9477942930f`
  __([view changes](https://github.com/nix-community/home-manager/compare/4de84265d7ec7634a69ba75028696d74de9a44a7...fbec89838763831bd92e1b09222dc9477942930f))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/3257ad7f173b0314c8a42fec450fa6556495b97c` →
  `github:nix-community/NixOS-WSL/e0b9e6c8ff35c7a28cb6baa02d85a9737a2ee4e9`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/3257ad7f173b0314c8a42fec450fa6556495b97c...e0b9e6c8ff35c7a28cb6baa02d85a9737a2ee4e9))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/1536926ef5621b09bba54035ae2bb6d806d72ac8` →
  `github:nixos/nixpkgs/9df3e30ce24fd28c7b3e2de0d986769db5d6225d`
  __([view changes](https://github.com/nixos/nixpkgs/compare/1536926ef5621b09bba54035ae2bb6d806d72ac8...9df3e30ce24fd28c7b3e2de0d986769db5d6225d))__
* __vscode-server:__ 
  `github:msteen/nixos-vscode-server/1e1358493df6529d4c7bc4cc3066f76fd16d4ae6` →
  `github:msteen/nixos-vscode-server/d0ed9b8cf1f0a71f110df9119489ab047e0726bd`
  __([view changes](https://github.com/msteen/nixos-vscode-server/compare/1e1358493df6529d4c7bc4cc3066f76fd16d4ae6...d0ed9b8cf1f0a71f110df9119489ab047e0726bd))__