### PR TITLE
build(deps): bump flake inputs `flake-utils`, `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710043165,
-        "narHash": "sha256-R34OB9q1JMqbIQlnuccWFGDYG0sWEALHxjL6kQGVR44=",
+        "lastModified": 1712989663,
+        "narHash": "sha256-r2X/DIAyKOLiHoncjcxUk1TENWDTTaigRBaY53Cts/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fbec89838763831bd92e1b09222dc9477942930f",
+        "rev": "40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709980437,
-        "narHash": "sha256-rp1MwfRaZl7TPM4E5i1HxQGJCCfMcIa7dOzTX3SW7ro=",
+        "lastModified": 1712984363,
+        "narHash": "sha256-VgCqYB+ymQuZmno8B82L8piyENo5xTNuqubnACYoBRk=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "e0b9e6c8ff35c7a28cb6baa02d85a9737a2ee4e9",
+        "rev": "0479d4c1ebeb314c5281b4aa7109def821a1b27b",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709703039,
-        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/d465f4819400de7c8d874d50b982301f28a84605` →
  `github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a`
  __([view changes](https://github.com/numtide/flake-utils/compare/d465f4819400de7c8d874d50b982301f28a84605...b1d9ab70662946ef0850d488da1c9019f3a9752a))__
* __home-manager:__ 
  `github:nix-community/home-manager/fbec89838763831bd92e1b09222dc9477942930f` →
  `github:nix-community/home-manager/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0`
  __([view changes](https://github.com/nix-community/home-manager/compare/fbec89838763831bd92e1b09222dc9477942930f...40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/e0b9e6c8ff35c7a28cb6baa02d85a9737a2ee4e9` →
  `github:nix-community/NixOS-WSL/0479d4c1ebeb314c5281b4aa7109def821a1b27b`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/e0b9e6c8ff35c7a28cb6baa02d85a9737a2ee4e9...0479d4c1ebeb314c5281b4aa7109def821a1b27b))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/9df3e30ce24fd28c7b3e2de0d986769db5d6225d` →
  `github:nixos/nixpkgs/1042fd8b148a9105f3c0aca3a6177fd1d9360ba5`
  __([view changes](https://github.com/nixos/nixpkgs/compare/9df3e30ce24fd28c7b3e2de0d986769db5d6225d...1042fd8b148a9105f3c0aca3a6177fd1d9360ba5))__