### PR TITLE
build(deps): bump flake input `home-manager`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712989663,
-        "narHash": "sha256-r2X/DIAyKOLiHoncjcxUk1TENWDTTaigRBaY53Cts/w=",
+        "lastModified": 1713077896,
+        "narHash": "sha256-Noot8H0EZEAFRQWyGxh9ryvhK96xpIqKbh78X447JWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0",
+        "rev": "630a0992b3627c64e34f179fab68e3d48c6991c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0` →
  `github:nix-community/home-manager/630a0992b3627c64e34f179fab68e3d48c6991c0`
  __([view changes](https://github.com/nix-community/home-manager/compare/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0...630a0992b3627c64e34f179fab68e3d48c6991c0))__