### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713077896,
-        "narHash": "sha256-Noot8H0EZEAFRQWyGxh9ryvhK96xpIqKbh78X447JWs=",
+        "lastModified": 1713547559,
+        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "630a0992b3627c64e34f179fab68e3d48c6991c0",
+        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712984363,
-        "narHash": "sha256-VgCqYB+ymQuZmno8B82L8piyENo5xTNuqubnACYoBRk=",
+        "lastModified": 1713528946,
+        "narHash": "sha256-IBQta+xrEaI2S5UmYrXcgV7Tu7rGLQu2V3TeJseLPSg=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "0479d4c1ebeb314c5281b4aa7109def821a1b27b",
+        "rev": "63c1247e12f269396ed2df8cdec3aed1f0f3928c",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1713297878,
+        "narHash": "sha256-hOkzkhLT59wR8VaMbh1ESjtZLbGi+XNaBN6h49SPqEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "66adc1e47f8784803f2deb6cacd5e07264ec2d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/630a0992b3627c64e34f179fab68e3d48c6991c0` →
  `github:nix-community/home-manager/938357cb234e85da37109df2cdd9cc59ab9c1cc0`
  __([view changes](https://github.com/nix-community/home-manager/compare/630a0992b3627c64e34f179fab68e3d48c6991c0...938357cb234e85da37109df2cdd9cc59ab9c1cc0))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/0479d4c1ebeb314c5281b4aa7109def821a1b27b` →
  `github:nix-community/NixOS-WSL/63c1247e12f269396ed2df8cdec3aed1f0f3928c`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/0479d4c1ebeb314c5281b4aa7109def821a1b27b...63c1247e12f269396ed2df8cdec3aed1f0f3928c))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/1042fd8b148a9105f3c0aca3a6177fd1d9360ba5` →
  `github:nixos/nixpkgs/66adc1e47f8784803f2deb6cacd5e07264ec2d5c`
  __([view changes](https://github.com/nixos/nixpkgs/compare/1042fd8b148a9105f3c0aca3a6177fd1d9360ba5...66adc1e47f8784803f2deb6cacd5e07264ec2d5c))__