### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713547559,
-        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
+        "lastModified": 1713682182,
+        "narHash": "sha256-2RSqVmQMFmn6OjQ21SXnWC+HuSeqDLWLftRv/ZhEDZE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
+        "rev": "4cec20dbf5c0a716115745ae32531e34816ecbbe",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713297878,
-        "narHash": "sha256-hOkzkhLT59wR8VaMbh1ESjtZLbGi+XNaBN6h49SPqEc=",
+        "lastModified": 1713537308,
+        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "66adc1e47f8784803f2deb6cacd5e07264ec2d5c",
+        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/938357cb234e85da37109df2cdd9cc59ab9c1cc0` →
  `github:nix-community/home-manager/4cec20dbf5c0a716115745ae32531e34816ecbbe`
  __([view changes](https://github.com/nix-community/home-manager/compare/938357cb234e85da37109df2cdd9cc59ab9c1cc0...4cec20dbf5c0a716115745ae32531e34816ecbbe))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/66adc1e47f8784803f2deb6cacd5e07264ec2d5c` →
  `github:nixos/nixpkgs/5c24cf2f0a12ad855f444c30b2421d044120c66f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/66adc1e47f8784803f2deb6cacd5e07264ec2d5c...5c24cf2f0a12ad855f444c30b2421d044120c66f))__