### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixos-wsl`, `nixpkgs`, `vscode-server`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713682182,
-        "narHash": "sha256-2RSqVmQMFmn6OjQ21SXnWC+HuSeqDLWLftRv/ZhEDZE=",
+        "lastModified": 1714203603,
+        "narHash": "sha256-eT7DENhYy7EPLOqHI9zkIMD9RvMCXcqh6gGqOK5BWYQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4cec20dbf5c0a716115745ae32531e34816ecbbe",
+        "rev": "c1609d584a6b5e9e6a02010f51bd368cb4782f8e",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713528946,
-        "narHash": "sha256-IBQta+xrEaI2S5UmYrXcgV7Tu7rGLQu2V3TeJseLPSg=",
+        "lastModified": 1714134704,
+        "narHash": "sha256-jgTn20s3qzar/IqhjQcEO+dIQbT4hBFIloVntiCURkA=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "63c1247e12f269396ed2df8cdec3aed1f0f3928c",
+        "rev": "4fb773cffed9bf1efdabcc01b25637eaeb4e8e9c",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713537308,
-        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709622318,
-        "narHash": "sha256-bTscF0366xtoIXgH7Zq+Mn0mpX3w4h/2xKpHiYMyLNc=",
+        "lastModified": 1713958148,
+        "narHash": "sha256-8PDNi/dgoI2kyM7uSiU4eoLBqUKoA+3TXuz+VWmuCOc=",
         "owner": "msteen",
         "repo": "nixos-vscode-server",
-        "rev": "d0ed9b8cf1f0a71f110df9119489ab047e0726bd",
+        "rev": "fc900c16efc6a5ed972fb6be87df018bcf3035bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/4cec20dbf5c0a716115745ae32531e34816ecbbe` →
  `github:nix-community/home-manager/c1609d584a6b5e9e6a02010f51bd368cb4782f8e`
  __([view changes](https://github.com/nix-community/home-manager/compare/4cec20dbf5c0a716115745ae32531e34816ecbbe...c1609d584a6b5e9e6a02010f51bd368cb4782f8e))__
* __nixos-wsl:__ 
  `github:nix-community/NixOS-WSL/63c1247e12f269396ed2df8cdec3aed1f0f3928c` →
  `github:nix-community/NixOS-WSL/4fb773cffed9bf1efdabcc01b25637eaeb4e8e9c`
  __([view changes](https://github.com/nix-community/NixOS-WSL/compare/63c1247e12f269396ed2df8cdec3aed1f0f3928c...4fb773cffed9bf1efdabcc01b25637eaeb4e8e9c))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/5c24cf2f0a12ad855f444c30b2421d044120c66f` →
  `github:nixos/nixpkgs/7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856`
  __([view changes](https://github.com/nixos/nixpkgs/compare/5c24cf2f0a12ad855f444c30b2421d044120c66f...7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856))__
* __vscode-server:__ 
  `github:msteen/nixos-vscode-server/d0ed9b8cf1f0a71f110df9119489ab047e0726bd` →
  `github:msteen/nixos-vscode-server/fc900c16efc6a5ed972fb6be87df018bcf3035bc`
  __([view changes](https://github.com/msteen/nixos-vscode-server/compare/d0ed9b8cf1f0a71f110df9119489ab047e0726bd...fc900c16efc6a5ed972fb6be87df018bcf3035bc))__