### PR TITLE
revert: switch back to zen kernel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,26 +123,6 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -357,7 +337,6 @@
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "git-hooks": "git-hooks",
-        "gitignore": "gitignore",
         "home-manager": "home-manager",
         "import-tree": "import-tree",
         "llm-agents": "llm-agents",

--- a/flake.nix
+++ b/flake.nix
@@ -65,13 +65,7 @@
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-compat.follows = "flake-compat";
-        gitignore.follows = "gitignore";
       };
-    };
-
-    gitignore = {
-      url = "github:hercules-ci/gitignore.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     home-manager = {

--- a/modules/packages/bmad-method.nix
+++ b/modules/packages/bmad-method.nix
@@ -8,18 +8,18 @@
     let
       bmad-method = pkgs.buildNpmPackage (finalAttrs: {
         pname = "bmad-method";
-        version = "6.9.0";
+        version = "6.10.0";
 
         src = pkgs.fetchFromGitHub {
           owner = "bmad-code-org";
           repo = "BMAD-METHOD";
           tag = "v${finalAttrs.version}";
           # hash = lib.fakeHash;
-          hash = "sha256-K0kTv+fiRO2pBIvspNwfE8ovAmULCSMjgjBjVHYpbIs=";
+          hash = "sha256-xnJmArPoV7+cRL8nHm5ETJd6A1rXQ0RfcuMT01oggEk=";
         };
 
         # npmDepsHash = lib.fakeHash;
-        npmDepsHash = "sha256-djTw5Cnq6FCc0wRLEvs8QQM+FljBSSokNJEZ+e3BtTE=";
+        npmDepsHash = "sha256-VYoyAhCZ6CRc/5QXuNfXTzRDvX/zIQhpx3zrj8me2TQ=";
 
         dontNpmBuild = true;
         npmPrune = false;


### PR DESCRIPTION
Revert the changes from commit e709af5c874dad6a62623620303ace97fa712aff that switched from linuxPackages_zen to the standard kernel.

This restores the zen kernel configuration pending resolution of the NVIDIA open driver compatibility issue.